### PR TITLE
Remove unneccessary checks for cha_list_set and location_list_set

### DIFF
--- a/kitchen/ph5tostationxml.py
+++ b/kitchen/ph5tostationxml.py
@@ -470,12 +470,6 @@ class PH5toStationXML(object):
         
                 if self.args.get('level') and (
                     self.args.get('level').upper() == "STATION" or self.args.get('level').upper() == "NETWORK"):
-                    
-                    if station.selected_number_of_channels == 0:
-                        if self.cha_list_set == 0 and self.location_list_set == 0:
-                            all_stations.append(station)
-                        else:
-                            continue
                     all_stations.append(station)
                     
 

--- a/webservices/ph5tostationxml.py
+++ b/webservices/ph5tostationxml.py
@@ -470,12 +470,6 @@ class PH5toStationXML(object):
         
                 if self.args.get('level') and (
                     self.args.get('level').upper() == "STATION" or self.args.get('level').upper() == "NETWORK"):
-                    
-                    if station.selected_number_of_channels == 0:
-                        if self.cha_list_set == 0 and self.location_list_set == 0:
-                            all_stations.append(station)
-                        else:
-                            continue
                     all_stations.append(station)
                     
 


### PR DESCRIPTION
Please merge if you are okay with removing this check. It causes the program to return no data when wildcards are specified for location or channel in ph5tostationxml.py.