### PR TITLE
Fix bug in get_nonrestricted_segments

### DIFF
--- a/kitchen/ph5tomsAPI.py
+++ b/kitchen/ph5tomsAPI.py
@@ -246,11 +246,13 @@ class PH5toMSeed(object):
                 restricted = copy.deepcopy(restricted)
                 station_to_cut_segments = copy.deepcopy(station_to_cut_segments)
             for seg_to_cut in station_to_cut_list:
+                is_restricted_sncl = False
                 for r in restricted:
                     if r.network == seg_to_cut.net_code and \
                        r.station == seg_to_cut.seed_station and \
                        r.location == seg_to_cut.location and \
                        r.channel == seg_to_cut.seed_channel:
+                        is_restricted_sncl = True
                         # restricted-range-start <= station_to_cut <= restricted-range-end
                         # -- station_to_cut inside restricted-range
                         if (seg_to_cut.starttime >= r.starttime and \
@@ -304,6 +306,9 @@ class PH5toMSeed(object):
                             # entire segment is non-restricted
                             if seg_to_cut not in station_to_cut_segments:
                                 station_to_cut_segments.append(seg_to_cut)
+                if not is_restricted_sncl:
+                    if seg_to_cut not in station_to_cut_segments:
+                        station_to_cut_segments.append(seg_to_cut)
             return station_to_cut_segments
         else:
             return station_to_cut_list

--- a/kitchen/test_ph5tomsAPI.py
+++ b/kitchen/test_ph5tomsAPI.py
@@ -134,5 +134,28 @@ class TestPH5toMSeed(unittest.TestCase):
         self.assertEqual(expected4.__dict__, result[3].__dict__, msg="Restricted inside of request. 4nd Segment")
         self.assertEqual(len(result), 4)
         
+        # not in restricted list at all
+        st = 1438794000.0
+        et = 1489589791.0
+        station_to_cut = StationCut(net_code="4C",
+                                 station="1003",
+                                 seed_station="DAN",
+                                 das="10811",
+                                 channel="1",
+                                 seed_channel="DPZ",
+                                 starttime=st,
+                                 endtime=et,
+                                 sample_rate=250,
+                                 sample_rate_multiplier=1,
+                                 notimecorrect=False,
+                                 location="",
+                                 latitude=-123.14976,
+                                 longitude=46.23013
+                                 )
+        station_to_cut_list = [station_to_cut]
+        expected = copy.deepcopy(station_to_cut)
+        result = PH5toMSeed.get_nonrestricted_segments(station_to_cut_list, restricted_list)
+        self.assertEqual(result[0].__dict__, expected.__dict__)
+        
 if __name__ == "__main__":
     unittest.main()

--- a/webservices/ph5tomsAPI.py
+++ b/webservices/ph5tomsAPI.py
@@ -246,11 +246,13 @@ class PH5toMSeed(object):
                 restricted = copy.deepcopy(restricted)
                 station_to_cut_segments = copy.deepcopy(station_to_cut_segments)
             for seg_to_cut in station_to_cut_list:
+                is_restricted_sncl = False
                 for r in restricted:
                     if r.network == seg_to_cut.net_code and \
                        r.station == seg_to_cut.seed_station and \
                        r.location == seg_to_cut.location and \
                        r.channel == seg_to_cut.seed_channel:
+                        is_restricted_sncl = True
                         # restricted-range-start <= station_to_cut <= restricted-range-end
                         # -- station_to_cut inside restricted-range
                         if (seg_to_cut.starttime >= r.starttime and \
@@ -304,6 +306,9 @@ class PH5toMSeed(object):
                             # entire segment is non-restricted
                             if seg_to_cut not in station_to_cut_segments:
                                 station_to_cut_segments.append(seg_to_cut)
+                if not is_restricted_sncl:
+                    if seg_to_cut not in station_to_cut_segments:
+                        station_to_cut_segments.append(seg_to_cut)
             return station_to_cut_segments
         else:
             return station_to_cut_list

--- a/webservices/test_ph5tomsAPI.py
+++ b/webservices/test_ph5tomsAPI.py
@@ -134,5 +134,28 @@ class TestPH5toMSeed(unittest.TestCase):
         self.assertEqual(expected4.__dict__, result[3].__dict__, msg="Restricted inside of request. 4nd Segment")
         self.assertEqual(len(result), 4)
         
+        # not in restricted list at all
+        st = 1438794000.0
+        et = 1489589791.0
+        station_to_cut = StationCut(net_code="4C",
+                                 station="1003",
+                                 seed_station="DAN",
+                                 das="10811",
+                                 channel="1",
+                                 seed_channel="DPZ",
+                                 starttime=st,
+                                 endtime=et,
+                                 sample_rate=250,
+                                 sample_rate_multiplier=1,
+                                 notimecorrect=False,
+                                 location="",
+                                 latitude=-123.14976,
+                                 longitude=46.23013
+                                 )
+        station_to_cut_list = [station_to_cut]
+        expected = copy.deepcopy(station_to_cut)
+        result = PH5toMSeed.get_nonrestricted_segments(station_to_cut_list, restricted_list)
+        self.assertEqual(result[0].__dict__, expected.__dict__)
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
After some more testing I found that I didn't account for the case where there is a list of restricted requested segments but not every requested SNCL is in the restricted list. This change addresses that case and includes an updated unit-test.