### PR TITLE
Fix #47

### DIFF
--- a/kitchen/ph5toexml.py
+++ b/kitchen/ph5toexml.py
@@ -216,7 +216,8 @@ class PH5toexml(object):
             return True     
 
     def get_fdsn_time(self, epoch, microseconds):
-        fdsn_time=datetime.utcfromtimestamp(epoch+microseconds).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        seconds = microseconds/1000000.
+        fdsn_time=datetime.utcfromtimestamp(epoch+seconds).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         return fdsn_time    
 
     def read_events(self, name):


### PR DESCRIPTION
Fix for mismatched request by shot filename datetime and actual event times. There was a bug in the ph5utils.py `get_fdsn_time` method, where a microseond to second conversion was required before converting to utcdatetime.