### PR TITLE
Fixes 1 second bug found occasionally in node data

### DIFF
--- a/kitchen/ph5tomsAPI.py
+++ b/kitchen/ph5tomsAPI.py
@@ -37,7 +37,7 @@ import itertools
 import ph5utils
 
 
-PROG_VERSION = "2017.159 BETA"
+PROG_VERSION = "2017.159"
 
 
 class StationCut(object):

--- a/kitchen/ph5tomsAPI.py
+++ b/kitchen/ph5tomsAPI.py
@@ -314,6 +314,8 @@ class PH5toMSeed(object):
                 start_time_micro_seconds = 0
     
             nt = stc.notimecorrect
+            
+            
             traces = self.ph5.cut(stc.das, start_time,
                                   stc.endtime,
                                   chan=stc.channel,
@@ -340,10 +342,8 @@ class PH5toMSeed(object):
                 obspy_trace.stats.coordinates.longitude = stc.longitude
                 obspy_trace.stats.channel = stc.seed_channel
                 obspy_trace.stats.network = stc.net_code
-                obspy_trace.stats.starttime = UTCDateTime(trace.start_time.epoch())
-    
-                obspy_trace.stats.starttime.microsecond = (
-                    start_time_micro_seconds)
+                obspy_trace.stats.starttime = UTCDateTime(trace.start_time.epoch(fepoch=True))
+            
     
                 if self.decimation:
                     obspy_trace.decimate(int(self.decimation))

--- a/kitchen/ph5tomsAPI.py
+++ b/kitchen/ph5tomsAPI.py
@@ -121,9 +121,7 @@ class PH5toMSeed(object):
         
         if self.reqtype == "SHOT":    
             self.ph5.read_event_t_names()
-            
 
-        
         if not self.stream and not os.path.exists(self.out_dir):
             try:
                 os.mkdir(self.out_dir)
@@ -316,8 +314,7 @@ class PH5toMSeed(object):
                 start_time_micro_seconds = 0
     
             nt = stc.notimecorrect
-            
-            
+
             traces = self.ph5.cut(stc.das, start_time,
                                   stc.endtime,
                                   chan=stc.channel,
@@ -345,8 +342,7 @@ class PH5toMSeed(object):
                 obspy_trace.stats.channel = stc.seed_channel
                 obspy_trace.stats.network = stc.net_code
                 obspy_trace.stats.starttime = UTCDateTime(trace.start_time.epoch(fepoch=True))
-            
-    
+
                 if self.decimation:
                     obspy_trace.decimate(int(self.decimation))
                 obspy_stream.append(obspy_trace)
@@ -470,9 +466,7 @@ class PH5toMSeed(object):
                     stop_fepoch = start_fepoch + self.length  
                 else:     
                     stop_fepoch = ph5API.fepoch(pickup, pickup_micro)                
-            
-            
-            
+
             if (self.use_deploy_pickup is True and not
                     ((start_fepoch >= deploy and
                       stop_fepoch <= pickup))):
@@ -505,8 +499,6 @@ class PH5toMSeed(object):
                     seconds_covered += seconds
                     times_to_cut.append([start_time, stop_time])
                     start_time = stop_time
-                          
-                   
             else:
                 times_to_cut = [[start_fepoch, stop_fepoch]]
                 times_to_cut[-1][-1] = stop_fepoch
@@ -834,8 +826,6 @@ if __name__ == '__main__':
         args.component = args.component.split(',')
     if args.channel:
         args.channel = args.channel.split(',')
-        
-
 
     try:
         ph5ms = PH5toMSeed( ph5API_object, out_dir=args.out_dir, reqtype=args.reqtype, 
@@ -849,7 +839,6 @@ if __name__ == '__main__':
 
         streams = ph5ms.process_all()
 
-
         if args.format and args.format.upper() == "MSEED":
             for t in streams:
                 if not args.stream:
@@ -862,7 +851,6 @@ if __name__ == '__main__':
     
                 else:
                     t.write(sys.stdout, format='MSEED', reclen=4096)
-    
         elif args.format and args.format.upper() == "SAC":
             for t in streams:
                 if not args.stream:
@@ -874,11 +862,8 @@ if __name__ == '__main__':
     
                 else:
                     t.write(sys.stdout, format='SAC')
-    
         else:
-    
             for t in streams:
-    
                 if not args.stream:
                     t.write(ph5ms.filenamemseed_gen(t), format='MSEED',
                             reclen=4096)
@@ -897,4 +882,3 @@ if __name__ == '__main__':
     sys.stdout.write(str(tm() - then))
     
     ph5API_object.close()
-    

--- a/kitchen/ph5tomsAPI.py
+++ b/kitchen/ph5tomsAPI.py
@@ -37,7 +37,7 @@ import itertools
 import ph5utils
 
 
-PROG_VERSION = "2017.134"
+PROG_VERSION = "2017.159 BETA"
 
 
 class StationCut(object):
@@ -122,6 +122,8 @@ class PH5toMSeed(object):
         if self.reqtype == "SHOT":    
             self.ph5.read_event_t_names()
             
+
+        
         if not self.stream and not os.path.exists(self.out_dir):
             try:
                 os.mkdir(self.out_dir)
@@ -464,9 +466,13 @@ class PH5toMSeed(object):
             
                     if float(check_end_time) < float(deploy):
                         continue
-                else:
+                elif self.length:
+                    stop_fepoch = start_fepoch + self.length  
+                else:     
                     stop_fepoch = ph5API.fepoch(pickup, pickup_micro)                
-
+            
+            
+            
             if (self.use_deploy_pickup is True and not
                     ((start_fepoch >= deploy and
                       stop_fepoch <= pickup))):
@@ -499,6 +505,8 @@ class PH5toMSeed(object):
                     seconds_covered += seconds
                     times_to_cut.append([start_time, stop_time])
                     start_time = stop_time
+                          
+                   
             else:
                 times_to_cut = [[start_fepoch, stop_fepoch]]
                 times_to_cut[-1][-1] = stop_fepoch
@@ -752,7 +760,7 @@ def get_args():
         type=float, default=-1., help=argparse.SUPPRESS)
 
     parser.add_argument(
-        "-l", "--length", action="store", default=60,
+        "-l", "--length", action="store", default=None,
         type=int, dest="length", metavar="length")
 
     parser.add_argument(
@@ -826,9 +834,11 @@ if __name__ == '__main__':
         args.component = args.component.split(',')
     if args.channel:
         args.channel = args.channel.split(',')
+        
+
 
     try:
-        ph5ms = PH5toMSeed( ph5API_object, out_dir=".", reqtype=args.reqtype, 
+        ph5ms = PH5toMSeed( ph5API_object, out_dir=args.out_dir, reqtype=args.reqtype, 
                  netcode=args.network, station=args.sta_list, station_id=args.sta_id_list, 
                  channel=args.channel, component=args.component, array=args.array, 
                  shotline=args.shotline, eventnumbers=args.eventnumbers, length=args.length, 
@@ -885,3 +895,6 @@ if __name__ == '__main__':
         exit(-1)
 
     sys.stdout.write(str(tm() - then))
+    
+    ph5API_object.close()
+    


### PR DESCRIPTION
obspy_trace.stats.starttime.microsecond = (start_time_micro_seconds) interacted strangely with node data sometimes causing a 1 second offset. 

Also made sure floating point version of trace.start_time.epoch() was passed to obspy
