### PR TITLE
Fix bug with day of year breakup date format not matching expected format.

### DIFF
--- a/ph5/core/ph5utils.py
+++ b/ph5/core/ph5utils.py
@@ -138,7 +138,7 @@ def doy_breakup(start_fepoch):
     :returns: stop_fepoch : next days stop epoch :type: float
               seconds: difference in seconds between the start and end epoch times :type: float
     """
-    passcal_start = epoch2passcal(start_fepoch)
+    passcal_start = epoch2passcal(float(start_fepoch))
     start_passcal_list = passcal_start.split(":")
     start_year = start_passcal_list[0] 
     start_doy = start_passcal_list[1]


### PR DESCRIPTION
Fix for the following bug:

```
(venv) falco:pic-ph5 nick$ python PH5WebService/PH5DataQuery/ph5dataselect.py --network=4C --station=DAN --starttime=2015-08-04T16:30:00 --endtime=2017-08-04T16:30:00
Traceback (most recent call last):
  File "PH5WebService/PH5DataQuery/ph5dataselect.py", line 248, in <module>
    run_dataselect_service()
  File "PH5WebService/PH5DataQuery/ph5dataselect.py", line 237, in run_dataselect_service
    write_to_stream(args.format.upper(), request_dict)
  File "PH5WebService/PH5DataQuery/ph5dataselect.py", line 223, in write_to_stream
    wrote_data = write_mseed(request_dict)
  File "PH5WebService/PH5DataQuery/ph5dataselect.py", line 193, in write_mseed
    for stream in data_obj.process_all():
  File "/Users/nick/Development/workspace/pic-ph5/PH5WebService/apps/ph5tomsAPI.py", line 649, in process_all
    for cut in cuts:
  File "/Users/nick/Development/workspace/pic-ph5/PH5WebService/apps/ph5tomsAPI.py", line 493, in create_cut
    stop_time, seconds = ph5utils.doy_breakup(start_fepoch)
  File "/Users/nick/Development/workspace/pic-ph5/PH5WebService/apps/ph5utils.py", line 152, in doy_breakup
    passcal_date = datetime.strptime(datestr, "%Y:%j:%H:%M:%S.%f")
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/_strptime.py", line 325, in _strptime
    (data_string, format))
ValueError: time data '2015:216:16:30:00' does not match format '%Y:%j:%H:%M:%S.%f'
Closing remaining open files:/hdf5-data2/PH5_Experiments/pn4/15-018/master.ph5…done
```