### PR TITLE
1 Sample Phase Shift fix

### DIFF
--- a/ph5/clients/ph5tomsAPI.py
+++ b/ph5/clients/ph5tomsAPI.py
@@ -341,7 +341,7 @@ class PH5toMSeed(object):
                 obspy_trace.stats.coordinates.longitude = stc.longitude
                 obspy_trace.stats.channel = stc.seed_channel
                 obspy_trace.stats.network = stc.net_code
-                obspy_trace.stats.starttime = UTCDateTime(trace.start_time.epoch(fepoch=True))
+                obspy_trace.stats.starttime = trace.start_time.getFdsnTime()
 
                 if self.decimation:
                     obspy_trace.decimate(int(self.decimation))


### PR DESCRIPTION
datetime object conversion inside TimeDoy was causing a rounding error. This can be avoided by passing the correct unrounded fdsn time directly to obspy without using epoch time.