### PR TITLE
Remove environment name from environment.yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -q -n ph5 python=$TRAVIS_PYTHON_VERSION
   - conda config --add channels obspy
-  - conda env update --file environment.yml
+  - conda env update --name ph5 --file environment.yml
   - source activate ph5
 # command to run tests
 script: python runtests.py

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ After downloading the installer execute the associated shell script. For example
 Below are explainations of the various ways you can install PH5. PH5 has several [system requirements](https://github.com/PIC-IRIS/PH5/wiki/PH5-Requirements) that are necessary for installation.
 
 ### Installing from source
-* Open a terminal and clone the PH5 project
+* Open a terminal.
 * Clone the PH5 project from GitHub to your local machine.
 * Add the conda-forge channel to your Anaconda configuration by running `conda config --add channels conda-forge`
 * Create a new Anaconda Virtual Environment for ph5 by running `conda env create -q --name=ph5 python=2.7`

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Below are explainations of the various ways you can install PH5. PH5 has several
 * Open a terminal and clone the PH5 project
 * Clone the PH5 project from GitHub to your local machine.
 * Add the conda-forge channel to your Anaconda configuration by running `conda config --add channels conda-forge`
-* Install PH5 Dependencies by running `conda env update -f=/path/to/ph5/environment.yml`. PH5 dependencies will be 
-created in a new Anaconda Virtual Environment called _ph5_
+* Create a new Anaconda Virtual Environment for ph5 by running `conda env create -q --name=ph5 python=2.7`
+* Install PH5 dependencies into the environment by running `conda env update --name=ph5 -f=/path/to/ph5/environment.yml`
 * Source the newly created ph5 environment by running `source activate ph5`
 * Install the PH5 python package by running `python setup.py install` in the cloned PH5 project root directory.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,3 @@
-name: ph5
 dependencies:
  - six
  - Cython


### PR DESCRIPTION
I'm working on removing the hardcoded _ph5_ environment name from the environment.yml file. This should be in the create command not in the environment.yml file.