### PR TITLE
Change the QuakeML custom namespace to 'iris' instead of 'PH5' 

### DIFF
--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -495,7 +495,7 @@ class PH5toexml(object):
                 catalog.events=events
             
             if catalog.events:
-                catalog.write(outfile, "QUAKEML",  nsmap={"PH5": iris_custom_ns})
+                catalog.write(outfile, "QUAKEML",  nsmap={"iris": iris_custom_ns})
             else:
                 raise NoDataError()
         


### PR DESCRIPTION
I had to change the custom namespace for the QuakeML output to "iris" instead of "PH5" in order to match the FDSNWS Event Web Service. It also is now consistent with the PH5WS Station Web Service output.