### PR TITLE
Change event text format option to be selected as just 'text' instead of 'shottext'.

### DIFF
--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -504,7 +504,7 @@ class PH5toexml(object):
             write_exml(list_of_networks)
         elif out_format.upper() == "KML":
             write_kml(list_of_networks)
-        elif out_format.upper() == "SHOTTEXT":
+        elif out_format.upper() == "TEXT":
             write_text(list_of_networks)  
         elif out_format.upper() == "XML":
             write_quakeml(list_of_networks)          


### PR DESCRIPTION
Another very small change to the event service. Instead of selected the pipe delimited text format as "shottext" the format option is now just "text".