### PR TITLE
Revert "Change event text format option to be selected as just 'text' instead of 'shottext'."

### DIFF
--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -504,7 +504,7 @@ class PH5toexml(object):
             write_exml(list_of_networks)
         elif out_format.upper() == "KML":
             write_kml(list_of_networks)
-        elif out_format.upper() == "TEXT":
+        elif out_format.upper() == "SHOTTEXT":
             write_text(list_of_networks)  
         elif out_format.upper() == "XML":
             write_quakeml(list_of_networks)          


### PR DESCRIPTION
Reverts PIC-IRIS/PH5#99