### PR TITLE
Fix for set() 'in' operation not behaving the same as a list.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ Master:
   * Doy_breakup can now accept variable time lengths for breakup. Default is 1 day
 -ph5.clients.ph5tostationxml
   * Fixed array number bug
-  * Use set in read_stations for speedup
+  * Use Hash for station comparison to speed up read_stations()
 -ph5.clients.ph5toms
   * Fixed array number bug
   * Added LENGTH global variable to adjust file cuts

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -553,6 +553,7 @@ class PH5toStationXMLParser(object):
     def read_stations(self):
 
         all_stations = set()
+        all_stations_keys = []
         for sta_xml_obj in self.manager.request_list:
             array_patterns = sta_xml_obj.array_list
             for array_name in self.array_names:
@@ -630,7 +631,14 @@ class PH5toStationXMLParser(object):
                                                                 station_list
                                                                )
                         obs_station.selected_number_of_channels = 0
-                    if obs_station not in all_stations:
+                    hash = "{}.{}.{}.{}.{}.{}".format(obs_station.code,
+                                                      obs_station.latitude,
+                                                      obs_station.longitude,
+                                                      obs_station.start_date,
+                                                      obs_station.end_date,
+                                                      obs_station.elevation)
+                    if hash not in all_stations_keys:
+                        all_stations_keys.append(hash)
                         all_stations.add(obs_station)
         all_stations_list = list(all_stations)
         all_stations_list.sort()

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -552,7 +552,7 @@ class PH5toStationXMLParser(object):
 
     def read_stations(self):
 
-        all_stations = set()
+        all_stations = []
         all_stations_keys = []
         for sta_xml_obj in self.manager.request_list:
             array_patterns = sta_xml_obj.array_list
@@ -639,10 +639,8 @@ class PH5toStationXMLParser(object):
                                                       obs_station.elevation)
                     if hash not in all_stations_keys:
                         all_stations_keys.append(hash)
-                        all_stations.add(obs_station)
-        all_stations_list = list(all_stations)
-        all_stations_list.sort()
-        return all_stations_list                        
+                        all_stations.append(obs_station)
+        return all_stations                        
  
 
     def read_arrays(self, name):


### PR DESCRIPTION
The "in" operation wasn't working in the same way on the set() in read stations. This was causing duplicate stations to get added on POST requests.  The fix was to create a separate list of hashes each representing a station. This list can be used to track what has already been added to the set().