### PR TITLE
Improve performance by using the Python built-in datetime.utcfromtimestamp

### DIFF
--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -227,7 +227,8 @@ class PH5toStationXMLRequest(object):
         if not self.array_list:
             self.array_list = ["*"]
         if self.start_time:
-            self.start_time = UTCDateTime(ns=ph5utils.sec_to_nanosec(start_time))
+            self.start_time = UTCDateTime(
+                                    ns=ph5utils.sec_to_nanosec(start_time))
         if self.end_time:
             self.end_time = UTCDateTime(ns=ph5utils.sec_to_nanosec(end_time))
 
@@ -320,10 +321,10 @@ class PH5toStationXMLParser(object):
 
         obs_station.creation_date = UTCDateTime(
             ns=ph5utils.sec_to_nanosec(station_list[deployment][0]
-                                    ['deploy_time/epoch_l']))
+                                       ['deploy_time/epoch_l']))
         obs_station.termination_date = UTCDateTime(
             ns=ph5utils.sec_to_nanosec(station_list[deployment][0]
-                                    ['pickup_time/epoch_l']))
+                                       ['pickup_time/epoch_l']))
 
         extra = AttribDict({
             'PH5Array': {
@@ -351,10 +352,10 @@ class PH5toStationXMLParser(object):
                                             )
         obs_channel.start_date = UTCDateTime(
             ns=ph5utils.sec_to_nanosec(station_list[deployment][0]
-                                    ['deploy_time/epoch_l']))
+                                       ['deploy_time/epoch_l']))
         obs_channel.end_date = UTCDateTime(
             ns=ph5utils.sec_to_nanosec(station_list[deployment][0]
-                                    ['pickup_time/epoch_l']))
+                                       ['pickup_time/epoch_l']))
 
         # compute sample rate
         sample_rate_multiplier = float(station_list[deployment]
@@ -396,7 +397,7 @@ class PH5toStationXMLParser(object):
                                                     ['deploy_time/epoch_l'])),
             removal_date=UTCDateTime(ns=ph5utils.sec_to_nanosec(
                                         station_list[deployment][0]
-                                                   ['pickup_time/epoch_l'])))
+                                        ['pickup_time/epoch_l'])))
         das_type = " ".join([x for x in [station_list[deployment][0]
                                                      ['das/manufacturer_s'],
                                          station_list[deployment][0]
@@ -598,17 +599,19 @@ class PH5toStationXMLParser(object):
                                                      sta_latitude,
                                                      sta_longitude):
                             continue
-    
+
                         if station_list[deployment][0]['seed_station_name_s']:
-                            station_name = \
-                                station_list[deployment][0]['seed_station_name_s']
+                            station_name = station_list[deployment][0][
+                                                        'seed_station_name_s']
                         else:
                             station_name = x
-    
-                        start_date = station_list[deployment][0]['deploy_time/epoch_l']
+
+                        start_date = station_list[deployment][0][
+                                                        'deploy_time/epoch_l']
                         start_date = UTCDateTime(ns=ph5utils.sec_to_nanosec(
                                                                 start_date))
-                        end_date = station_list[deployment][0]['pickup_time/epoch_l']
+                        end_date = station_list[deployment][0][
+                                                        'pickup_time/epoch_l']
                         end_date = UTCDateTime(ns=ph5utils.sec_to_nanosec(
                                                                 end_date))
                         if sta_xml_obj.start_time and \
@@ -619,7 +622,6 @@ class PH5toStationXMLParser(object):
                                 sta_xml_obj.end_time < start_date:
                             # chosen end time before pickup
                             continue
-
 
                         obs_station = self.create_obs_station(station_list,
                                                               station_name,

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -5,13 +5,12 @@ Extracts station metadata from PH5 as StationXML or in other formats.
 import sys
 import io
 import os
-import datetime
+from datetime import datetime
 import argparse
 import fnmatch
 import obspy
 from obspy import read_inventory  # noqa
 from obspy.core.util import AttribDict
-from obspy.core import UTCDateTime
 import multiprocessing
 
 from ph5.core import ph5utils, ph5api
@@ -297,8 +296,8 @@ class PH5toStationXMLParser(object):
                 self.experiment_t[0]['experiment_id_s']
             obs_network.description = self.experiment_t[0]['longname_s']
             start_time, end_time = self.get_network_date()
-            obs_network.start_date = UTCDateTime(start_time)
-            obs_network.end_date = UTCDateTime(end_time)
+            obs_network.start_date = datetime.utcfromtimestamp(start_time)
+            obs_network.end_date = datetime.utcfromtimestamp(end_time)
             obs_network.total_number_of_stations = self.total_number_stations
             obs_network.stations = obs_stations
             return obs_network
@@ -315,10 +314,12 @@ class PH5toStationXMLParser(object):
                                                    start_date=start_date,
                                                    end_date=end_date,
                                                    elevation=sta_elevation)
-        obs_station.creation_date = UTCDateTime(
+
+        obs_station.creation_date = datetime.utcfromtimestamp(
             station_list[deployment][0]['deploy_time/epoch_l'])
-        obs_station.termination_date = UTCDateTime(
+        obs_station.termination_date = datetime.utcfromtimestamp(
             station_list[deployment][0]['pickup_time/epoch_l'])
+
         extra = AttribDict({
             'PH5Array': {
                 'value': str(array_name)[8:],
@@ -343,21 +344,25 @@ class PH5toStationXMLParser(object):
                                                    elevation=cha_elevation,
                                                    depth=0
                                             )
-        obs_channel.start_date = UTCDateTime(
+        obs_channel.start_date = datetime.utcfromtimestamp(
             station_list[deployment][0]['deploy_time/epoch_l'])
-        obs_channel.end_date = UTCDateTime(
+        obs_channel.end_date = datetime.utcfromtimestamp(
             station_list[deployment][0]['pickup_time/epoch_l'])
-        obs_channel.sample_rate = float(station_list[
-            deployment][0]['sample_rate_i'])/float(station_list[deployment][0]
-                                                   ['sample_rate_multiplier_i']
-                                                   )
-        obs_channel.sample_rate_ration = station_list[
-            deployment][0]['sample_rate_multiplier_i']
-        obs_channel.storage_format = "PH5"
 
+        # compute sample rate
+        sample_rate_multiplier = float(station_list[deployment]
+                                       [0]['sample_rate_multiplier_i'])
+        sample_rate_ration = float(station_list[deployment]
+                                   [0]['sample_rate_i'])
+        obs_channel.sample_rate_ration = sample_rate_ration
+        try:
+            obs_channel.sample_rate = sample_rate_ration/sample_rate_multiplier
+        except ZeroDivisionError:
+            raise PH5toStationXMLError(
+                            "Error - Invalid sample_rate_multiplier_i == 0")
+
+        obs_channel.storage_format = "PH5"
         receiver_table_n_i = station_list[deployment][0]['receiver_table_n_i']
-        self.response_table_n_i = \
-            station_list[deployment][0]['response_table_n_i']
         Receiver_t = self.manager.ph5.get_receiver_t_by_n_i(receiver_table_n_i)
         obs_channel.azimuth = Receiver_t['orientation/azimuth/value_f']
         obs_channel.dip = Receiver_t['orientation/dip/value_f']
@@ -379,10 +384,11 @@ class PH5toStationXMLParser(object):
             model=station_list[deployment][0]['sensor/model_s'],
             serial_number=station_list[deployment][0]
                                       ['sensor/serial_number_s'],
-            installation_date=UTCDateTime(station_list[deployment][0]
-                                                      ['deploy_time/epoch_l']),
-            removal_date=UTCDateTime(station_list[deployment][0]
-                                     ['pickup_time/epoch_l']))
+            installation_date=datetime.utcfromtimestamp(
+                                        station_list[deployment][0]
+                                                    ['deploy_time/epoch_l']),
+            removal_date=datetime.utcfromtimestamp(station_list[deployment][0]
+                                                   ['pickup_time/epoch_l']))
         das_type = " ".join([x for x in [station_list[deployment][0]
                                                      ['das/manufacturer_s'],
                                          station_list[deployment][0]
@@ -396,10 +402,10 @@ class PH5toStationXMLParser(object):
                 model=station_list[deployment][0]['das/model_s'],
                 serial_number=station_list[deployment][0]
                                           ['das/serial_number_s'],
-                installation_date=UTCDateTime(
+                installation_date=datetime.utcfromtimestamp(
                         station_list[deployment][0]['deploy_time/epoch_l']
                         ),
-                removal_date=UTCDateTime(
+                removal_date=datetime.utcfromtimestamp(
                         station_list[deployment][0]['pickup_time/epoch_l']
                         )
             )
@@ -422,6 +428,8 @@ class PH5toStationXMLParser(object):
                 (self.manager.level == "CHANNEL" and
                  self.manager.format == "TEXT"):
             # read response and add it to obspy channel inventory
+            self.response_table_n_i = \
+                station_list[deployment][0]['response_table_n_i']
             obs_channel.response = self.get_response_inv(obs_channel)
 
         return obs_channel
@@ -582,20 +590,17 @@ class PH5toStationXMLParser(object):
                                                      sta_latitude,
                                                      sta_longitude):
                             continue
-
+    
                         if station_list[deployment][0]['seed_station_name_s']:
                             station_name = \
-                                station_list[deployment][0][
-                                    'seed_station_name_s']
+                                station_list[deployment][0]['seed_station_name_s']
                         else:
                             station_name = x
-
-                        start_date = station_list[deployment][0][
-                            'deploy_time/epoch_l']
-                        start_date = UTCDateTime(start_date)
-                        end_date = station_list[deployment][0][
-                            'pickup_time/epoch_l']
-                        end_date = UTCDateTime(end_date)
+    
+                        start_date = station_list[deployment][0]['deploy_time/epoch_l']
+                        start_date = datetime.utcfromtimestamp(start_date)
+                        end_date = station_list[deployment][0]['pickup_time/epoch_l']
+                        end_date = datetime.utcfromtimestamp(end_date)
                         if sta_xml_obj.start_time and \
                                 sta_xml_obj.start_time > end_date:
                             # chosen start time after pickup
@@ -604,6 +609,7 @@ class PH5toStationXMLParser(object):
                                 sta_xml_obj.end_time < start_date:
                             # chosen end time before pickup
                             continue
+
 
                         obs_station = self.create_obs_station(station_list,
                                                               station_name,
@@ -841,7 +847,7 @@ def run_ph5_to_stationxml(paths, nickname, out_format,
                                         networks=networks,
                                         source="PIC-PH5",
                                         sender="IRIS-PASSCAL-DMC-PH5",
-                                        created=datetime.datetime.now(),
+                                        created=datetime.now(),
                                         module=("PH5 WEB SERVICE: metadata "
                                                 "| version: 1"),
                                         module_uri=uri)

--- a/ph5/core/ph5utils.py
+++ b/ph5/core/ph5utils.py
@@ -13,10 +13,11 @@ import time
 
 def does_pattern_exists(patterns_list, value):
     """
-    Checks a list of patterns against a value. 
+    Checks a list of patterns against a value.
     :param: patterns_list : A list of regular glob expression strings
     :type: str
-    :returns: Returns True if any of the patterns match the value, False otherwise.
+    :returns: Returns True if any of the patterns match the value,
+        False otherwise.
     :type: boolean
     """
     for pattern in patterns_list:
@@ -25,8 +26,8 @@ def does_pattern_exists(patterns_list, value):
     return False
 
 
-def is_radial_intersection(point_lat, point_lon, 
-                           minradius, maxradius, 
+def is_radial_intersection(point_lat, point_lon,
+                           minradius, maxradius,
                            latitude, longitude):
     """
     Checks if there is a radial intersection between a point radius boundary
@@ -38,7 +39,8 @@ def is_radial_intersection(point_lat, point_lon,
     :param: latitude : the latitude of the point to check :type: float
     :param: longitude : the longitude of the point to check :type: float
     """
-    if minradius != None or maxradius != None or point_lat != None or point_lon != None:
+    if minradius is not None or maxradius is not None or \
+       point_lat is not None or point_lon is not None:
         # min radius default to 0.0
         if not minradius:
             minradius = 0.0
@@ -72,16 +74,16 @@ def is_rect_intersection(minlat, maxlat, minlon, maxlon, latitude, longitude):
     :param: latitude : the latitude of the point to check :type: float
     :param: longitude : the longitude of the point to check :type: float
     """
-    if minlat != None and float(
+    if minlat is not None and float(
             minlat) > float(latitude):
         return False
-    elif minlon != None and float(
+    elif minlon is not None and float(
             minlon) > float(longitude):
         return False
-    elif maxlat != None and float(
+    elif maxlat is not None and float(
             maxlat) < float(latitude):
         return False
-    elif maxlon != None and float(
+    elif maxlon is not None and float(
             maxlon) < float(longitude):
         return False
     else:
@@ -97,12 +99,14 @@ def datestring_to_datetime(date_str):
     :type: datetime
     """
     if isinstance(date_str, (str, unicode)):
-        fmts = ("%Y:%j:%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d")
+        fmts = ("%Y:%j:%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S.%f",
+                "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d")
         for fmt in fmts:
             try:
                 dt = datetime.strptime(date_str, fmt)
                 if dt.year < 1900:
-                    err_msg = 'Date %s is out of range. Year must be year >= 1900.' % date_str
+                    err_msg = ('Date %s is out of range. '
+                               'Year must be year >= 1900.' % date_str)
                     raise ValueError(err_msg)
                 return dt
             except ValueError:
@@ -110,9 +114,10 @@ def datestring_to_datetime(date_str):
         err_msg = 'Unsupported date format. %s' % date_str
         raise ValueError(err_msg)
     elif isinstance(date_str, datetime):
-        return date_str # already a date
+        return date_str  # already a date
     else:
-        raise ValueError("Got {0} expected str or unicode.".format(type(date_str)))
+        raise ValueError("Got {0} expected str or unicode.".format(
+                                                            type(date_str)))
 
 
 def fdsntime_to_epoch(fdsn_time):
@@ -135,24 +140,25 @@ def doy_breakup(start_fepoch, length=86400):
     :param: start_fepoch
     :type: float
     :returns: stop_fepoch : next days stop epoch :type: float
-              seconds: difference in seconds between the start and end epoch times :type: float
+              seconds: difference in seconds between the start and end
+              epoch times :type: float
     """
     passcal_start = epoch2passcal(float(start_fepoch))
     start_passcal_list = passcal_start.split(":")
-    start_year = start_passcal_list[0] 
+    start_year = start_passcal_list[0]
     start_doy = start_passcal_list[1]
     start_hour = start_passcal_list[2]
     start_minute = start_passcal_list[3]
     start_second = start_passcal_list[4]
 
-    datestr = "{0}:{1}:{2}:{3}:{4}".format(start_year, start_doy, 
-                                               start_hour, start_minute, 
-                                               start_second)
+    datestr = "{0}:{1}:{2}:{3}:{4}".format(start_year, start_doy,
+                                           start_hour, start_minute,
+                                           start_second)
     passcal_date = datetime.strptime(datestr, "%Y:%j:%H:%M:%S.%f")
 
     next_passcal_date = passcal_date + timedelta(seconds=length)
     next_passcal_date_str = next_passcal_date.strftime("%Y:%j:%H:%M:%S.%f")
-    
+
     stop_fepoch = passcal2epoch(next_passcal_date_str, fepoch=True)
     seconds = stop_fepoch - start_fepoch
     return stop_fepoch, seconds

--- a/ph5/core/ph5utils.py
+++ b/ph5/core/ph5utils.py
@@ -166,3 +166,13 @@ def microsecs_to_sec(microsec):
     :returns: seconds :type: integer
     """
     return microsec / 1000000
+
+
+def sec_to_nanosec(sec):
+    """
+    Given seconds returns nanoseconds
+    :param: secons
+    :type: integer
+    :returns: nano-seconds :type: integer
+    """
+    return int(sec * 10**9)


### PR DESCRIPTION
I was able to get a big performance improvement by using the Python built-in `datetime.utcfromtimestamp` method instead of the ObsPy `UTCDatetime` method for converting epoch (int) times.

On my local computer, a request for all of the channel level StationXML metadata in the pn4 archive that used to take ~11 seconds now takes ~6 seconds. 

I also added a check for a sample rate multiplier of 0, raising an exception where necessary.