### PR TITLE
ph5toms Write Proper SAC Header

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,6 @@
 Master:
+-ph5.clients.ph5toms (issue #127)
+ * Updated ph5toms to write SAC header values properly
 -ph5.clients.ph5toevt
   * Updated to check the array table for response_n_i
 -ph5.clients.ph5torec


### PR DESCRIPTION
Addressing issue #127, ph5toms now writes proper header values into SAC output. To save time on non SAC output PH5toMSEED class now includes output format  in it's init so that the create_trace routine only loads the receiver tables for SAC since it is not needed for MSEED output.

in the main() function the method for writing out SAC was changed so that file names and times in the SAC header would be properly written. 