### PR TITLE
environment.yml pyqt4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
  - numexpr
  - pyproj
  - PySide
+ - pyqt=4
  - psutil
  - matplotlib<2
  - basemap


### PR DESCRIPTION
make sure pyqt4 is installed via environment.yml
In some cases we have found pyqt5 is installed instead of pyqt4