### PR TITLE
Fix for case where station does not have a key of 1.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,6 @@
 Master:
+-ph5.clients.ph5toexml
+ * Fix case where station does not have a key of 1
 -ph5.utilities.ph5_validate
  * New functionality for checking stations
 

--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -300,19 +300,27 @@ class PH5toexml(object):
         for array_name in array_names:
             arraybyid = self.ph5.Array_t[array_name]['byid']
             arrayorder = self.ph5.Array_t[array_name]['order']
-            for x in arrayorder:
-                station = arraybyid.get(x)
-                for idx in station:
-                    micro = ph5utils.microsecs_to_sec(
-                        station[idx][0]['deploy_time/micro_seconds_i'])
-                    deploy_time = station[idx][0]['deploy_time/epoch_l'] + micro
-                    micro = ph5utils.microsecs_to_sec(
-                        station[idx][0]['pickup_time/micro_seconds_i'])
-                    pickup_time = station[idx][0]['pickup_time/epoch_l'] + micro
-                    if earliest_deploy is None or earliest_deploy > deploy_time:
-                        earliest_deploy = deploy_time
-                    if latest_pickup is None or latest_pickup < pickup_time:
-                        latest_pickup = pickup_time
+            for ph5_station in arrayorder:
+                station_list = arraybyid.get(ph5_station)
+                for deployment in station_list:
+                    station_len = len(station_list[deployment])
+                    for st_num in range(0, station_len):
+                        micro = ph5utils.microsecs_to_sec(
+                            station_list[deployment][st_num]
+                            ['deploy_time/micro_seconds_i'])
+                        deploy_time = (station_list[deployment][st_num]
+                                       ['deploy_time/epoch_l'] + micro)
+                        micro = ph5utils.microsecs_to_sec(
+                            station_list[deployment][st_num]
+                            ['pickup_time/micro_seconds_i'])
+                        pickup_time = (station_list[deployment][st_num]
+                                       ['pickup_time/epoch_l'] + micro)
+                        if earliest_deploy is None or \
+                                earliest_deploy > deploy_time:
+                            earliest_deploy = deploy_time
+                        if latest_pickup is None or \
+                                latest_pickup < pickup_time:
+                            latest_pickup = pickup_time
 
         if self.args.get('start_time') and self.args.get(
                 'start_time') < datetime.fromtimestamp(earliest_deploy):

--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -302,16 +302,17 @@ class PH5toexml(object):
             arrayorder = self.ph5.Array_t[array_name]['order']
             for x in arrayorder:
                 station = arraybyid.get(x)
-                micro = ph5utils.microsecs_to_sec(
-                    station[1][0]['deploy_time/micro_seconds_i'])
-                deploy_time = station[1][0]['deploy_time/epoch_l'] + micro
-                micro = ph5utils.microsecs_to_sec(
-                    station[1][0]['pickup_time/micro_seconds_i'])
-                pickup_time = station[1][0]['pickup_time/epoch_l'] + micro
-                if earliest_deploy is None or earliest_deploy > deploy_time:
-                    earliest_deploy = deploy_time
-                if latest_pickup is None or latest_pickup < pickup_time:
-                    latest_pickup = pickup_time
+                for idx in station:
+                    micro = ph5utils.microsecs_to_sec(
+                        station[idx][0]['deploy_time/micro_seconds_i'])
+                    deploy_time = station[idx][0]['deploy_time/epoch_l'] + micro
+                    micro = ph5utils.microsecs_to_sec(
+                        station[idx][0]['pickup_time/micro_seconds_i'])
+                    pickup_time = station[idx][0]['pickup_time/epoch_l'] + micro
+                    if earliest_deploy is None or earliest_deploy > deploy_time:
+                        earliest_deploy = deploy_time
+                    if latest_pickup is None or latest_pickup < pickup_time:
+                        latest_pickup = pickup_time
 
         if self.args.get('start_time') and self.args.get(
                 'start_time') < datetime.fromtimestamp(earliest_deploy):


### PR DESCRIPTION
In certain cases the a station record does not have a key of 1, causing ph5toexml.py to crash. This was the case with experiment 17-013 (YV).

I'm not completely sure how the stations are indexed when accessed from `arraybyid` and `arrayorder`.

i.e. https://github.com/PIC-IRIS/PH5/blob/master/ph5/clients/ph5toexml.py#L300-L304

My worry is that there are other places where the code is making assumptions about the PH5 experiments that aren't always true.