### PR TITLE
Fix #181 and print ph5tostationxml to stdout by default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 Master:
 -ph5.utilities.kefedit
  * Fix bugs caused when loading PH5 experiment without offset tables
+-ph5.clients.ph5tostationxml
+ * Address issue #181
+ * print to stdout by default
  
 v4.1.1:
 -ph5.clients.ph5toexml

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -45,7 +45,7 @@ def get_args():
                         type=str, metavar="reportnum_list")
 
     parser.add_argument("-o", "--outfile", action="store",
-                        default="something.xml", type=str, metavar="outfile")
+                        default=sys.stdout, type=str, metavar="outfile")
 
     parser.add_argument("-f", "--format", action="store",
                         default="STATIONXML", dest="out_format",
@@ -925,7 +925,7 @@ def main():
         elif out_format == "SACPZ":
             inv.write(args.outfile, format="SACPZ")
         elif out_format == "TEXT":
-            inv.write(args.outfile, format="STATIONTXT")
+            inv.write(args.outfile, format="STATIONTXT", level=level)
         else:
             sys.stderr.write("Incorrect output format. "
                              "Formats are STATIONXML or KML")


### PR DESCRIPTION
- Bug fix for text format resulting in error. #181
- Print to stdout by default in instead of a file. Users can still optionally print to a file.