### PR TITLE
Remove new line from ph5toexml geocsv field_unit header line

### DIFF
--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -586,7 +586,7 @@ class PH5toexml(object):
                     "#dataset: GeoCSV 2.0\n"
                     "#delimiter: |\n"
                     "#field_unit: unitless | unitless | unitless | unitless | "
-                    "ISO_8601 | degrees_north | degrees_east | meters | \n"
+                    "ISO_8601 | degrees_north | degrees_east | meters | "
                     "float | unitless\n"
                     "#field_type: string | string | string | string | "
                     "datetime | float | float | float | float | string\n"


### PR DESCRIPTION
This is a bug fix for an extra new line that was in the ph5toexml geocsv header.