### PR TITLE
ph5tostationxml hash bug

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,6 @@
 Master:
+-ph5.utilities.ph5tostationxml
+ * Fixed bug causing arrays with same station id_s to be filtered out
 -ph5.utilities.kefedit
  Fixed not being able to save directly to PH5 (issue #193)
 -ph5.clients.ph5view

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -17,7 +17,7 @@ from obspy.core import UTCDateTime
 from ph5.core import ph5utils, ph5api
 
 
-PROG_VERSION = "2017.314"
+PROG_VERSION = "2018.106"
 
 
 def get_args():
@@ -643,13 +643,14 @@ class PH5toStationXMLParser(object):
                             obs_station.total_number_of_channels = len(
                                 station_list)
                             obs_station.selected_number_of_channels = 0
-                        hash = "{}.{}.{}.{}.{}.{}".format(
+                        hash = "{}.{}.{}.{}.{}.{}.{}".format(
                             obs_station.code,
                             obs_station.latitude,
                             obs_station.longitude,
                             obs_station.start_date,
                             obs_station.end_date,
-                            obs_station.elevation)
+                            obs_station.elevation,
+                            obs_station.extra)
                         if hash not in all_stations_keys:
                             all_stations_keys.append(hash)
                             all_stations.append(obs_station)


### PR DESCRIPTION
fixes bug in ph5tostationxml that caused stations with the same metadata but different array to be filtered out