### PR TITLE
Add GeoCSV timeseries data format support to ph5toms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 dist
 *.egg-info
+*.so

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,7 +12,9 @@ Master:
 -ph5.clients.ph5tostationxml
  * Address issue #181
  * print to stdout by default
- 
+ -ph5.clients.ph5toms
+ * Add ph5toms support for the web service GeoCSV timeseries data format.
+
 v4.1.1:
 -ph5.clients.ph5toexml
  * Fix case where station does not have a key of 1

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -144,32 +144,27 @@ class PH5toMSeed(object):
     def filenamemseed_gen(self, stream):
 
         s = stream.traces[0].stats
-        secs = int(s.starttime.timestamp)
-        pre = epoch2passcal(secs, sep='_')
-        ret = "{0}.{1}.{2}.{3}.{4}.ms".format(pre, s.network, s.station,
-                                              s.location, s.channel)
+        ret = "{0}.{1}.{2}.{3}.{4}.ms".format(
+            s.network, s.station, s.location,
+            s.channel, s.starttime.strftime("%Y-%m-%dT%H:%M:%S.%f"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
 
     def filenamesac_gen(self, trace):
-
         s = trace.stats
-        secs = int(s.starttime.timestamp)
-        pre = epoch2passcal(secs, sep='.')
-        ret = "{0}.{1}.{2}.{3}.{4}.SAC".format(
-            s.network, s.station, s.location, s.channel, pre)
+        ret = "{0}.{1}.{2}.{3}.{4}.sac".format(
+            s.network, s.station, s.location,
+            s.channel, s.starttime.strftime("%Y-%m-%dT%H:%M:%S.%f"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
     
     def filenamegeocsv_gen(self, trace):
-
         s = trace.stats
-        secs = int(s.starttime.timestamp)
-        pre = epoch2passcal(secs, sep='.')
         ret = "{0}.{1}.{2}.{3}.{4}.csv".format(
-            s.network, s.station, s.location, s.channel, pre)
+            s.network, s.station, s.location,
+            s.channel, s.starttime.strftime("%Y-%m-%dT%H:%M:%S.%f"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -323,7 +323,7 @@ class PH5toMSeed(object):
             # parse sensor response if present
             if response_file_sensor_a_name:
                 response_file_sensor_a = \
-                    self.manager.ph5.ph5_g_responses.get_response(
+                    self.ph5.ph5_g_responses.get_response(
                                                 response_file_sensor_a_name
                                             )
                 with io.BytesIO(response_file_sensor_a) as buf:

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -15,10 +15,9 @@ import obspy
 import copy
 import itertools
 from ph5.core import ph5utils
-from ph5.core.ph5utils import PH5ResponseManager, PH5Response
+from ph5.core.ph5utils import PH5ResponseManager
 from ph5.core import ph5api
 from ph5.core.timedoy import epoch2passcal, passcal2epoch
-import multiprocessing as mp
 import io
 
 
@@ -108,7 +107,7 @@ class PH5toMSeed(object):
         self.ph5 = ph5API_object
         self.restricted = restricted
         self.format = format
-        
+
         self.resp_manager = PH5ResponseManager()
 
         if not self.ph5.Array_t_names:
@@ -161,7 +160,7 @@ class PH5toMSeed(object):
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
-    
+
     def filenamegeocsv_gen(self, trace):
         s = trace.stats
         ret = "{0}.{1}.{2}.{3}.{4}.csv".format(
@@ -297,7 +296,7 @@ class PH5toMSeed(object):
             return station_to_cut_segments
         else:
             return station_to_cut_list
-        
+
     def get_response_obj(self, stc):
         sensor_keys = [stc.sensor_type]
         datalogger_keys = [stc.das_manufacturer,
@@ -495,14 +494,16 @@ class PH5toMSeed(object):
         location = station_list[deployment][
             st_num]['seed_location_code_s']
         das = station_list[deployment][st_num]['das/serial_number_s']
-        das_manufacturer = station_list[deployment][st_num]\
-                                            ['das/manufacturer_s']
-        das_model = station_list[deployment][st_num]\
-                                            ['das/model_s']
+        das_manufacturer = station_list[deployment][st_num][
+                                        'das/manufacturer_s']
+        das_model = station_list[deployment][st_num][
+                                        'das/model_s']
         sensor_type = " ".join([x for x in
-                    [station_list[deployment][st_num]['sensor/manufacturer_s'],
-                     station_list[deployment][st_num]['sensor/model_s']] if x])
-                            
+                                [station_list[deployment][st_num][
+                                                    'sensor/manufacturer_s'],
+                                 station_list[deployment][st_num][
+                                                    'sensor/model_s']] if x])
+
         receiver_n_i = station_list[deployment][st_num]['receiver_table_n_i']
         response_n_i = station_list[deployment][st_num]['response_table_n_i']
 
@@ -707,7 +708,7 @@ class PH5toMSeed(object):
                 "{0} != {1}".format(self.netcode, seed_network))
 
         experiment_id = experiment_t[0]['experiment_id_s']
-        
+
         array_names = sorted(self.ph5.Array_t_names)
         self.read_events(None)
 
@@ -738,7 +739,7 @@ class PH5toMSeed(object):
                     "Error - requested shotid(s) do not exist.")
 
         for array_name in array_names:
-            array_code = array_name[8:] # get 3 digit array code
+            array_code = array_name[8:]  # get 3 digit array code
             if self.array:
                 array_patterns = self.array
                 if not ph5utils.does_pattern_exists(

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -148,7 +148,7 @@ class PH5toMSeed(object):
         s = stream.traces[0].stats
         ret = "{0}.{1}.{2}.{3}.{4}.ms".format(
             s.network, s.station, s.location,
-            s.channel, s.starttime.strftime("%Y-%m-%dT%H:%M:%S.%f"))
+            s.channel, s.starttime.strftime("%Y-%m-%dT%H%M%S.%f"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
@@ -157,7 +157,7 @@ class PH5toMSeed(object):
         s = trace.stats
         ret = "{0}.{1}.{2}.{3}.{4}.sac".format(
             s.network, s.station, s.location,
-            s.channel, s.starttime.strftime("%Y-%m-%dT%H:%M:%S.%f"))
+            s.channel, s.starttime.strftime("%Y-%m-%dT%H%M%S.%f"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
@@ -166,7 +166,7 @@ class PH5toMSeed(object):
         s = trace.stats
         ret = "{0}.{1}.{2}.{3}.{4}.csv".format(
             s.network, s.station, s.location,
-            s.channel, s.starttime.strftime("%Y-%m-%dT%H:%M:%S.%f"))
+            s.channel, s.starttime.strftime("%Y-%m-%dT%H%M%S.%f"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -797,7 +797,8 @@ class PH5toMSeed(object):
                                 cuts_generator.append(self.create_cut(
                                     seed_network, ph5_station,
                                     seed_station, start_times,
-                                    station_list, deployment, st_num))
+                                    station_list, deployment, st_num,
+                                    array_code, experiment_id))
                         elif self.reqtype == "FDSN":
                             # fdsn request
                             cuts_generator.append(self.create_cut(

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -15,6 +15,7 @@ from obspy.core.util import AttribDict
 from obspy.core import UTCDateTime
 
 from ph5.core import ph5utils, ph5api
+from ph5.core.ph5utils import PH5ResponseManager, PH5Response
 
 
 PROG_VERSION = "2017.314"
@@ -146,37 +147,6 @@ class PH5toStationXMLError(Exception):
     """
     def __init__(self, message=""):
         self.message = message
-
-
-class PH5ResponseManager(object):
-
-    def __init__(self):
-        self.responses = []
-
-    def add_response(self, sensor_keys, datalogger_keys, response):
-        self.responses.append(
-                        PH5Response(sensor_keys, datalogger_keys, response)
-                    )
-
-    def get_response(self, sensor_keys, datalogger_keys):
-        for ph5_resp in self.responses:
-            if set(sensor_keys) == set(ph5_resp.sensor_keys) and \
-               set(datalogger_keys) == set(ph5_resp.datalogger_keys):
-                return ph5_resp.response
-
-    def is_already_requested(self, sensor_keys, datalogger_keys):
-        for response in self.responses:
-            if set(sensor_keys) == set(response.sensor_keys) and \
-               set(datalogger_keys) == set(response.datalogger_keys):
-                return True
-        return False
-
-
-class PH5Response(object):
-    def __init__(self, sensor_keys, datalogger_keys, response):
-        self.sensor_keys = sensor_keys
-        self.datalogger_keys = datalogger_keys
-        self.response = response
 
 
 class PH5toStationXMLRequest(object):

--- a/ph5/core/ph5utils.py
+++ b/ph5/core/ph5utils.py
@@ -11,6 +11,36 @@ from ph5.core.timedoy import epoch2passcal, passcal2epoch
 import time
 
 
+class PH5Response(object):
+    def __init__(self, sensor_keys, datalogger_keys, response):
+        self.sensor_keys = sensor_keys
+        self.datalogger_keys = datalogger_keys
+        self.response = response
+
+
+class PH5ResponseManager(object):
+
+    def __init__(self):
+        self.responses = []
+
+    def add_response(self, sensor_keys, datalogger_keys, response):
+        self.responses.append(
+                        PH5Response(sensor_keys, datalogger_keys, response)
+                    )
+
+    def get_response(self, sensor_keys, datalogger_keys):
+        for ph5_resp in self.responses:
+            if set(sensor_keys) == set(ph5_resp.sensor_keys) and \
+               set(datalogger_keys) == set(ph5_resp.datalogger_keys):
+                return ph5_resp.response
+
+    def is_already_requested(self, sensor_keys, datalogger_keys):
+        for response in self.responses:
+            if set(sensor_keys) == set(response.sensor_keys) and \
+               set(datalogger_keys) == set(response.datalogger_keys):
+                return True
+        return False
+
 def does_pattern_exists(patterns_list, value):
     """
     Checks a list of patterns against a value.


### PR DESCRIPTION
I've added support for a new GeoCSV ASCII data format to ph5toms. Currently support is limited to the PH5 Web Services, but the could easily be added to the command line handler if we choose to do so. 

An example of the geocsv.tspair inline output is shown below:
```
# dataset: GeoCSV 2.0
# delimiter: ,
# SID: YW_1001__DP1
# sample_count: 250
# sample_rate_hz: 250.0
# start_time: 2016-06-21T16:43:58.000000Z
# latitude_deg: 36.62229742
# longitude_deg: -97.740955
# elevation_m: 322.23
# depth_m: 0
# azimuth_deg: 0.0
# dip_deg: 0.0
# instrument: FairfieldNodal node_5Hz
# scale_factor: 1.02964E+9
# scale_frequency_hz: 40.0
# scale_units: M/S
# reportnum: 16-015
# array: 001
# component: 1
# field_unit: UTC, Counts
# field_type: datetime, INTEGER
Time, Sample
2016-06-21T16:43:58.000000Z, -32
2016-06-21T16:43:58.004000Z, 23
2016-06-21T16:43:58.008000Z, -18
2016-06-21T16:43:58.012000Z, 54
2016-06-21T16:43:58.016000Z, 209
2016-06-21T16:43:58.020000Z, 286
2016-06-21T16:43:58.024000Z, 165
2016-06-21T16:43:58.028000Z, 135
2016-06-21T16:43:58.032000Z, 30
2016-06-21T16:43:58.036000Z, 104
2016-06-21T16:43:58.040000Z, 108
2016-06-21T16:43:58.044000Z, -15
... etc.
```

Example Web Service Requests (see [ph5wsbeta-dataselect docs](https://service.iris.edu/ph5wsbeta/dataselect/1/)):
- Example of a FDSN request. YW station 1001 data in GeoCSV in SLIST ZIP format
http://service.iris.edu/ph5wsbeta/dataselect/1/query?format=geocsv.zip.slist&network=YW&starttime=2016-06-21T16:43:58&endtime=2016-06-21T16:43:59&station=1001&nodata=404
- Example of a FDSN request. YW station 1001 data in GeoCSV in TSPAIR INLINE format. Auto scaled by instrument sensitivity.
http://service.iris.edu/ph5wsbeta/dataselect/1/query?format=geocsv.tspair.inline&network=YW&starttime=2016-06-21T16:43:58&endtime=2016-06-21T16:43:59&station=1001&scale=AUTO&nodata=404