### PR TITLE
Update ph5torec.py

### DIFF
--- a/ph5/clients/ph5torec.py
+++ b/ph5/clients/ph5torec.py
@@ -285,7 +285,7 @@ def gather () :
                     ###   Need to apply reduction velocity here
                     if ARGS.red_vel > 0. :
                         try :
-                            secs, errs = segyfactory.calc_red_vel_secs (Offset[o], ARGS.red_vel)
+                            secs, errs = segyfactory.calc_red_vel_secs (Offset_t[o], ARGS.red_vel)
                         except Exception as e :
                             secs = 0.
                             errs = "Can not calculate reduction velocity: {0}.".format (e.message)


### PR DESCRIPTION
Wrong variable referenced on line 288
Have edited to read the real offset variable:  Offset_t[o] 
This will produce real reduced velocities and stop the error messages in the ph5torec.log file that it cannot find the variable Offset 
Original code was writing segy files that did not have reduced velocity