### PR TITLE
Improve the way setup.py handles c_dependencies.

### DIFF
--- a/ph5/core/c_dependencies/subcd_py.py
+++ b/ph5/core/c_dependencies/subcd_py.py
@@ -1,19 +1,28 @@
-
 from distutils.core import setup, Extension
 import os
-import numpy
+
+try:
+    import numpy  # @UnusedImport # NOQA
+except ImportError:
+    msg = ("No module named numpy. "
+           "Please install numpy first, it is needed before installing PH5.")
+    raise ImportError(msg)
+
+
+def get_extension_options():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    options = ("bcd_py",
+               ["ph5/core/c_dependencies/bcd_py.c",
+                "ph5/core/c_dependencies/bcdwrapper_py.c"])
+    return options
 
 
 def install():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    
-    setup (name = "bcd_py", version = "2014.119", include_dirs = [numpy.get_include()],
-           ext_modules = [
-        Extension (
-        "bcd_py", ["{0}/bcd_py.c".format(dir_path),
-                   "{0}/bcdwrapper_py.c".format(dir_path)],
-        #extra_link_args = ["-m32"]
-    )])
+    setup (name="bcd_py",
+           version="2014.119",
+           ext_modules=[Extension(*get_extension_options(),
+                                  include_dirs=[numpy.get_include()]
+                                  )])
 
 
 if __name__ == '__main__':

--- a/ph5/core/c_dependencies/sufirfilt_py.py
+++ b/ph5/core/c_dependencies/sufirfilt_py.py
@@ -1,20 +1,28 @@
-
-#   Run with pnpython2
 from distutils.core import setup, Extension
 import os
-import numpy
+
+try:
+    import numpy  # @UnusedImport # NOQA
+except ImportError:
+    msg = ("No module named numpy. "
+           "Please install numpy first, it is needed before installing PH5.")
+    raise ImportError(msg)
+
+
+def get_extension_options():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    options = ("firfilt_py",
+               ["ph5/core/c_dependencies/firfilt_py.c", 
+               "ph5/core/c_dependencies/firfiltwrapper_py.c"])
+    return options
 
 
 def install():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    
-    setup (name = "firfilt_py", version = "2010.153", include_dirs = [numpy.get_include()],
-           ext_modules = [
-        Extension (
-        "firfilt_py", ["{0}/firfilt_py.c".format(dir_path), 
-                       "{0}/firfiltwrapper_py.c".format(dir_path)],
-        #extra_link_args = ["-m32"]
-    )])
+    setup (name="firfilt_py",
+           version="2010.153",
+           ext_modules=[Extension(*get_extension_options(),
+                                  include_dirs=[numpy.get_include()]
+                                  )])
 
 
 if __name__ == '__main__':

--- a/ph5/core/c_dependencies/suibm2ieee_py.py
+++ b/ph5/core/c_dependencies/suibm2ieee_py.py
@@ -1,19 +1,29 @@
-
 from distutils.core import setup, Extension
 import os
-import numpy
+
+
+try:
+    import numpy  # @UnusedImport # NOQA
+except ImportError:
+    msg = ("No module named numpy. "
+           "Please install numpy first, it is needed before installing PH5.")
+    raise ImportError(msg)
+
+
+def get_extension_options():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    options = ("ibm2ieee_py",
+               ["ph5/core/c_dependencies/ibm2ieee_py.c",
+                "ph5/core/c_dependencies/ibm2ieeewrapper_py.c"])
+    return options
 
 
 def install():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    
-    setup (name = "ibm2iee_py", version = "2013.121", include_dirs = [numpy.get_include()],
-           ext_modules = [
-        Extension (
-        "ibm2ieee_py", ["{0}/ibm2ieee_py.c".format(dir_path),
-                        "{0}/ibm2ieeewrapper_py.c".format(dir_path)],
-        #extra_link_args = ["-m32"]
-    )])
+    setup (name="ibm2iee_py",
+           version="2013.121",
+           ext_modules=[Extension(*get_extension_options(),
+                                  include_dirs=[numpy.get_include()]
+                                  )])
 
 
 if __name__ == '__main__':

--- a/ph5/core/c_dependencies/surt_125a_py.py
+++ b/ph5/core/c_dependencies/surt_125a_py.py
@@ -1,19 +1,30 @@
-
 from distutils.core import setup, Extension
 import os
-import numpy
+
+
+try:
+    import numpy  # @UnusedImport # NOQA
+except ImportError:
+    msg = ("No module named numpy. "
+           "Please install numpy first, it is needed before installing PH5.")
+    raise ImportError(msg)
+
+
+def get_extension_options():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    options = ("rt_125a_py",
+               ["ph5/core/c_dependencies/rt_125a_py.c",
+                "ph5/core/c_dependencies/rt_125awrapper_py.c"])
+    return options
 
 
 def install():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    
-    setup (name = "rt_125a_py", version = "2010.169", include_dirs = [numpy.get_include()],
-           ext_modules = [
-        Extension (
-        "rt_125a_py", ["{0}/rt_125a_py.c".format(dir_path),
-                       "{0}/rt_125awrapper_py.c".format(dir_path)],
-        #extra_link_args = ["-m32"]
-    )])
+    setup (name="rt_125a_py",
+           version="2010.169",
+           include_dirs=[numpy.get_include()],
+           ext_modules=[Extension(*get_extension_options(),
+                                  include_dirs=[numpy.get_include()]
+                                  )])
 
 
 if __name__ == '__main__':

--- a/ph5/core/c_dependencies/surt_130_py.py
+++ b/ph5/core/c_dependencies/surt_130_py.py
@@ -1,19 +1,30 @@
-
 from distutils.core import setup, Extension
 import os
-import numpy
+
+
+try:
+    import numpy  # @UnusedImport # NOQA
+except ImportError:
+    msg = ("No module named numpy. "
+           "Please install numpy first, it is needed before installing PH5.")
+    raise ImportError(msg)
+
+
+def get_extension_options():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    options = ("rt_130_py",
+               ["ph5/core/c_dependencies/rt_130_py.c",
+                "ph5/core/c_dependencies/rt_130wrapper_py.c"])
+    return options
 
 
 def install():
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    
-    setup (name = "rt_130_py", version = "2001.273", include_dirs = [numpy.get_include()],
-           ext_modules = [
-        Extension (
-        "rt_130_py", ["{0}/rt_130_py.c".format(dir_path),
-                      "{0}/rt_130wrapper_py.c".format(dir_path)],
-        #extra_link_args = ["-m32"]
-    )])
+    setup (name="rt_130_py",
+           version="2001.273",
+           include_dirs=[numpy.get_include()],
+           ext_modules=[Extension(*get_extension_options(),
+                                  include_dirs=[numpy.get_include()]
+                                  )])
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+six
+Cython
+nose
+numpy
+numexpr
+pyproj
+psutil
+obspy
+vispy
+pyicu
+lxml
+construct==2.5.1
+simplekml
+tables
+matplotlib<2
+#pyqt4 - required external program
+#PySide - required external program

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,15 @@ https://github.com/pypa/sampleproject
 
 from __future__ import (print_function)
 
+# install C dependencies
+from ph5.core.c_dependencies import subcd_py
+from ph5.core.c_dependencies import sufirfilt_py
+from ph5.core.c_dependencies import suibm2ieee_py
+from ph5.core.c_dependencies import surt_125a_py
+from ph5.core.c_dependencies import surt_130_py
+
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
 from setuptools.command.install import install
 from setuptools.command.develop import develop
 from distutils import log
@@ -21,9 +28,41 @@ try:
 except ImportError:
     pass
 
+try:
+    import PyQt4
+except ImportError:
+    msg = ("No module named PyQt4. "
+           "Please install PyQt4 first, it is needed before installing PH5. "
+           "\n\n"
+           "If using Anaconda run 'conda install pyqt=4'"
+           "For pip users, PyQt4 installation instructions are available at "
+           "http://pyqt.sourceforge.net/Docs/PyQt4/installation.html.")
+    raise ImportError(msg)
+
+try:
+    import PySide
+except ImportError:
+    msg = ("No module named PySide. "
+           "Please install PySide first, it is needed before installing PH5. "
+           "\n\n"
+           "If using Anaconda run 'conda install PySide'"
+           "For pip users, PySide installation instructions are available at "
+           "https://pypi.org/project/PySide/#installation.")
+    raise ImportError(msg)
+
+try:
+    import numpy  # @UnusedImport # NOQA
+except ImportError:
+    msg = ("No module named numpy. "
+           "Please install numpy first, it is needed before installing PH5.")
+    raise ImportError(msg)
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setup(
     name="ph5",
-    version="4.1.2",
+    version="4.1.2_1",
     # metadata for upload to PyPI
     author="IRIS PASSCAL Instrument Center",
     author_email="dhess@passcal.nmt.edu",
@@ -31,6 +70,7 @@ setup(
     license="MIT",
     keywords="ph5 IRIS miniSEED sac segy seg-y segd seg-d",
     url="https://github.com/PIC-IRIS/PH5/",   # project home page, if any
+    install_requires=requirements,
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha
@@ -52,7 +92,6 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',    
     ],
-      
     entry_points = {
         'gui_scripts': [
             'ph5view = ph5.clients.ph5view.ph5_viewer:startapp',
@@ -109,27 +148,36 @@ setup(
             'unsimpleton = ph5.utilities.unsimpleton:main',
         ],
     },
-
-    packages=['ph5', 'ph5/clients', 'ph5/clients/ph5view', 'ph5/core', 'ph5/utilities'],
-
+    packages=['ph5',
+              'ph5/clients',
+              'ph5/clients/ph5view',
+              'ph5/core',
+              'ph5/core/c_dependencies',
+              'ph5/utilities'],
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
         'utilities': ['Event.cfg', 'Receiver.cfg'],
         'clients': ['PH5Viewer.cfg'],
+        'ph5/core/c_dependencies':
+                    ['bcd_py.cd', 'bcdwrapper_py.c',
+                     'firfilt_py.c', 'firfiltwrapper_py.c', 'fir.h',
+                     'ibm2ieee_py.c', 'ibm2ieeewrapper_py.c',
+                     'rt_125a_py.c', 'rt_125awrapper_py.c',
+                     'rt_130_py.c', 'rt_130wrapper_py.c', 'rt_130_py.h'
+                     ]
     },
-    
+    # install c-dependencies
+    ext_modules=[Extension(*subcd_py.get_extension_options(),
+                           include_dirs=[numpy.get_include()]),
+                 Extension(*sufirfilt_py.get_extension_options(),
+                           include_dirs=[numpy.get_include()]),
+                 Extension(*suibm2ieee_py.get_extension_options(),
+                           include_dirs=[numpy.get_include()]),
+                 Extension(*surt_125a_py.get_extension_options(),
+                           include_dirs=[numpy.get_include()]),
+                 Extension(*surt_130_py.get_extension_options(),
+                           include_dirs=[numpy.get_include()])]
 )
 
-# install C dependencies
-from ph5.core.c_dependencies import subcd_py
-from ph5.core.c_dependencies import sufirfilt_py
-from ph5.core.c_dependencies import suibm2ieee_py
-from ph5.core.c_dependencies import surt_125a_py
-from ph5.core.c_dependencies import surt_130_py
-subcd_py.install()
-sufirfilt_py.install()
-suibm2ieee_py.install()
-surt_125a_py.install()
-surt_130_py.install()


### PR DESCRIPTION
In the current (v4.1.2) and older versions of PH5, the c dependencies in the `~/ph5/core/c_dependencies/` directory get built separately from the PH5 package. This causes problems when deploying from `pip`. 

I created a new test release at https://test.pypi.org/manage/project/ph5/release/4.1.2-1/ that fixes this issue, by properly including these dependencies.