### PR TITLE
segd2ph5 read correct channel sets

### DIFF
--- a/ph5/utilities/segd2ph5.py
+++ b/ph5/utilities/segd2ph5.py
@@ -447,18 +447,13 @@ def process_traces(rh, th, tr):
 
     def get_true_channel():
         #   Find channel by mapping to streamer_cable_number
-        try:
+
+        if rh.channel_set_to_streamer_cable_map[th.trace_header.channel_set]\
+                == 0:
+            true_channel = th.trace_header.channel_set
+        else:
             true_channel = rh.channel_set_to_streamer_cable_map[
                 th.trace_header.channel_set]
-        except Exception as e:
-            logging.warn(
-                "There may be a problem with reel header\
-                 channel_set_to_streamer_cable_map.\nUsing channel set read\
-                  from the trace header.\n{0}\n".format(
-                    e.message))
-            true_channel = th.trace_header.channel_set
-        # print rh.channel_set_to_streamer_cable_map,\
-        # th.trace_header.channel_set, true_channel
         return true_channel
 
     def process_das():
@@ -500,7 +495,7 @@ def process_traces(rh, th, tr):
             # 1 (N node) -> 1 (N PH5), 2 (E Node)-> 2 (E PH5), 3 (Z Node) -> 0
             # (Z PH5)
             M = {1: 1, 2: 2, 3: 0}
-            p_das_t['receiver_table_n_i'] = M[th.trace_header.channel_set]
+            p_das_t['receiver_table_n_i'] = M[get_true_channel()]
         else:
             p_das_t['receiver_table_n_i'] = 0  # 0 -> Z
             logging.warn(
@@ -523,7 +518,7 @@ def process_traces(rh, th, tr):
         p_das_t['time/ascii_s'] = time.ctime(p_das_t['time/epoch_l'])
         p_das_t['time/micro_seconds_i'] = int(f * 1000000.)
         p_das_t['event_number_i'] = th.trace_header_N[1].shot_point
-        p_das_t['channel_number_i'] = th.trace_header.channel_set
+        p_das_t['channel_number_i'] = get_true_channel()
         p_das_t['sample_rate_i'] = SD.sample_rate
         p_das_t['sample_rate_multiplier_i'] = 1
         p_das_t['sample_count_i'] = len(tr)
@@ -692,9 +687,9 @@ def process_traces(rh, th, tr):
         else:
             OM = None
         if OM is None:
-            orientation_code = th.trace_header.channel_set
+            orientation_code = get_true_channel()
         else:
-            orientation_code = OM[th.trace_header.channel_set]
+            orientation_code = OM[get_true_channel()]
         # for cs in range (SD.chan_sets_per_scan) :
         p_array_t['seed_band_code_s'] = band_code
         p_array_t['seed_instrument_code_s'] = instrument_code
@@ -728,11 +723,11 @@ def process_traces(rh, th, tr):
         p_array_t['das/manufacturer_s'] = 'FairfieldNodal'
         DM = {1: 'ZLAND 1C', 3: "ZLAND 3C"}
         try:
-            p_array_t['das/model_s'] = DM[SD.chan_sets_per_scan]
-            # if SD.chan_sets_per_scan >= 3:
-            # p_array_t['das/model_s'] = DM[3]
-            # else:
-            # p_array_t['das/model_s'] = DM[1]
+            # p_array_t['das/model_s'] = DM[SD.chan_sets_per_scan]
+            if SD.chan_sets_per_scan >= 3:
+                p_array_t['das/model_s'] = DM[3]
+            else:
+                p_array_t['das/model_s'] = DM[1]
         except Exception as e:
             logging.warn(
                 "Failed to read channel sets per scan: {0}.".format(e.message))
@@ -771,7 +766,7 @@ def process_traces(rh, th, tr):
                 "Failed to read receiver point depth: {0}.".format(e.message))
             p_array_t['location/Z/value_d'] = 0.
 
-        p_array_t['channel_number_i'] = th.trace_header.channel_set
+        p_array_t['channel_number_i'] = get_true_channel()
         # p_array_t['description_s'] = str (th.trace_header_N[4].line_number)
         try:
             p_array_t['description_s'] = "DAS: {0}, Node ID: {1}".format(
@@ -787,7 +782,7 @@ def process_traces(rh, th, tr):
             logging.warn("Failed to read line number: {0}.".format(e.message))
             line = 0
 
-        chan_set = th.trace_header.channel_set
+        chan_set = get_true_channel()
         if line not in ARRAY_T:
             ARRAY_T[line] = {}
         if Das not in ARRAY_T[line]:


### PR DESCRIPTION
Fix for reading SEG-D where the number of channel sets exceeds the number of channels. This happens at either a high sample rate or when the window length is set very small on the node server during deployment.