### PR TITLE
Return empty response element in StationXML if a response was not loaded into PH5

### DIFF
--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -469,6 +469,8 @@ class PH5toStationXMLParser(object):
                         )
                 else:
                     return inv_resp
+            else:
+                return Response()
         else:
             inv_resp = self.resp_manager.get_response(sensor_keys,
                                                       datalogger_keys)


### PR DESCRIPTION
StationXML requires a Response element even if it is empty. This is a fix to always include a Response element in the XML output.