### PR TITLE
Fix bug reading responses in ph5tostationxml.

### DIFF
--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -437,9 +437,11 @@ class PH5toStationXMLParser(object):
                 with io.BytesIO(response_file_das_a) as buf:
                     buf.seek(0, 0)
                     if _is_resp(buf):
+                        buf.seek(0, 0)
                         dl_resp = read_inventory(buf, format="RESP")
                         dl_resp = dl_resp[0][0][0].response
                     else:
+                        buf.seek(0, 0)
                         dl_resp = pickle.loads(response_file_das_a)
 
             # parse sensor response if present
@@ -448,13 +450,15 @@ class PH5toStationXMLParser(object):
                     self.manager.ph5.ph5_g_responses.get_response(
                                                 response_file_sensor_a_name
                                             )
+
                 with io.BytesIO(response_file_sensor_a) as buf:
                     buf.seek(0, 0)
-
                     if _is_resp(buf):
+                        buf.seek(0, 0)
                         sensor_resp = read_inventory(buf, format="RESP")
                         sensor_resp = sensor_resp[0][0][0].response
                     else:
+                        buf.seek(0, 0)
                         sensor_resp = pickle.loads(response_file_sensor_a)
 
             inv_resp = None


### PR DESCRIPTION
### What does this PR do?
This is bug fix for reading response information from PH5 in ph5tostationxml. Calling the `_is_resp` method in ph5tostationxml  moves the position of the file pointer in the `buf` byte buffer so `buf.seek(0, 0)` needed to be called again after calling `_is_resp(buf)`. 
