### PR TITLE
Change command line file naming ph5toms

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ ph5.clients.ph5toms
  * Fix bug causing duplicate data to be written (issue #264)
  * FIx bug causing data to not be written in special cases at the start of the data in PH5
  * Slight change to naming output on command line for more consistency
+ * No longer adds extra sample at end of cut
 ph5.utilities.report_gen
  * add report_gen entry point to setup.py
 ph5.utilities.pformagui

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -12,6 +12,7 @@ import logging
 import copy
 import itertools
 import io
+import datetime
 from obspy.core.inventory.inventory import read_inventory as read_inventory
 from obspy import Trace
 from obspy import Stream
@@ -22,7 +23,7 @@ from ph5.core.ph5utils import PH5ResponseManager
 from ph5.core import ph5api
 from ph5.core.timedoy import epoch2passcal, passcal2epoch
 
-PROG_VERSION = '2019.74'
+PROG_VERSION = '2019.81'
 LOGGER = logging.getLogger(__name__)
 
 
@@ -148,45 +149,100 @@ class PH5toMSeed(object):
     def filenamemseed_gen(self, stream):
 
         s = stream.traces[0].stats
+        new_start = s.starttime.isoformat()
+        try:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S.%f"))
+        except BaseException:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S"))
         ret = "{0}.{1}.{2}.{3}.{4}.ms".format(
             s.network, s.station, s.location,
-            s.channel, s.starttime.strftime("%Y-%m-%dT%H.%M.%S"))
+            s.channel, rounded.strftime("%Y-%m-%dT%H.%M.%S"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
 
     def filenamesac_gen(self, trace):
         s = trace.stats
+        new_start = s.starttime.isoformat()
+        try:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S.%f"))
+        except BaseException:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S"))
         ret = "{0}.{1}.{2}.{3}.{4}.sac".format(
             s.network, s.station, s.location,
-            s.channel, s.starttime.strftime("%Y-%m-%dT%H.%M.%S"))
+            s.channel, rounded.strftime("%Y-%m-%dT%H.%M.%S"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
 
     def filenamegeocsv_gen(self, trace):
         s = trace.stats
+        new_start = s.starttime.isoformat()
+        try:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S.%f"))
+        except BaseException:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S"))
         ret = "{0}.{1}.{2}.{3}.{4}.csv".format(
             s.network, s.station, s.location,
-            s.channel, s.starttime.strftime("%Y-%m-%dT%H.%M.%S"))
+            s.channel, rounded.strftime("%Y-%m-%dT%H.%M.%S"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
 
     def filenamemseed_nongen(self, stream):
         s = stream.traces[0].stats
+        new_start = s.starttime.isoformat()
+        try:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S.%f"))
+        except BaseException:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S"))
         ret = "{0}.{1}.{2}.{3}.ms".format(
             s.array, s.station, s.channel,
-            s.starttime.strftime("%Y-%m-%dT%H.%M.%S"))
+            rounded.strftime("%Y-%m-%dT%H.%M.%S"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret
 
     def filenamesac_nongen(self, trace):
         s = trace.stats
+        new_start = s.starttime.isoformat()
+        try:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S.%f"))
+        except BaseException:
+            rounded = ph5utils.roundSeconds(
+                datetime.datetime.strptime(
+                    new_start,
+                    "%Y-%m-%dT%H:%M:%S"))
         ret = "{0}.{1}.{2}.{3}.sac".format(
             s.array, s.station, s.channel,
-            s.starttime.strftime("%Y-%m-%dT%H.%M.%S"))
+            rounded.strftime("%Y-%m-%dT%H.%M.%S"))
         if not self.stream:
             ret = os.path.join(self.out_dir, ret)
         return ret

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -23,7 +23,7 @@ from ph5.core.ph5utils import PH5ResponseManager
 from ph5.core import ph5api
 from ph5.core.timedoy import epoch2passcal, passcal2epoch
 
-PROG_VERSION = '2019.81'
+PROG_VERSION = '2019.84'
 LOGGER = logging.getLogger(__name__)
 
 
@@ -439,10 +439,6 @@ class PH5toMSeed(object):
             [station_to_cut], self.restricted)
         obspy_stream = Stream()
         for stc in station_to_cut_segments:
-            if stc.sample_rate != 0:
-                new_endtime = stc.endtime + (1 / float(stc.sample_rate))
-            else:
-                new_endtime = stc.endtime
             das = self.ph5.query_das_t(stc.das, stc.component,
                                        stc.starttime,
                                        stc.endtime,
@@ -476,14 +472,14 @@ class PH5toMSeed(object):
 
             if stc.sample_rate != 0:
                 traces = self.ph5.cut(stc.das, start_time,
-                                      new_endtime,
+                                      stc.endtime,
                                       chan=stc.component,
                                       sample_rate=actual_sample_rate,
                                       apply_time_correction=nt, das_t=das)
             else:
                 traces = self.ph5.textural_cut(stc.das,
                                                start_time,
-                                               new_endtime,
+                                               stc.endtime,
                                                chan=stc.component,
                                                das_t=das)
 

--- a/ph5/core/ph5utils.py
+++ b/ph5/core/ph5utils.py
@@ -15,7 +15,7 @@ from obspy.geodetics import locations2degrees
 from ph5.core.timedoy import epoch2passcal, passcal2epoch, TimeDOY, TimeError
 import time
 
-PROG_VERSION = "2019.63"
+PROG_VERSION = "2019.81"
 
 
 class PH5Response(object):
@@ -280,3 +280,12 @@ def microsecs_to_sec(microsec):
     if type(microsec) is not int:
         raise ValueError("microsec must be integer")
     return float(microsec) / 1000000
+
+
+def roundSeconds(dateTimeObject):
+    newDateTime = dateTimeObject
+
+    if newDateTime.microsecond >= 500000:
+        newDateTime = newDateTime + timedelta(seconds=1)
+
+    return newDateTime.replace(microsecond=0)

--- a/ph5/core/tests/test_ph5utils.py
+++ b/ph5/core/tests/test_ph5utils.py
@@ -388,6 +388,56 @@ class TestPH5Utils(unittest.TestCase):
              200])
         self.assertTrue(ret)
 
+    def test_RoundSeconds(self):
+        """
+        test RoundSeconds from datetime
+        """
+        # date only
+        date_only = datetime.datetime(2020, 5, 17)
+        rounded = ph5utils.roundSeconds(date_only)
+        # Should be the equal
+        self.assertEqual(date_only, rounded)
+
+        # time no microseconds
+        time_no_micro = datetime.datetime(2019, 1, 10, 5, 15, 10)
+        rounded = ph5utils.roundSeconds(time_no_micro)
+        self.assertEqual(time_no_micro, rounded)
+
+        # time microseconds round down
+        time_micro_down = datetime.datetime(2019, 1, 10, 5, 15, 10, 490000)
+        rounded = ph5utils.roundSeconds(time_micro_down)
+        self.assertEqual(
+            datetime.datetime(2019, 1, 10, 5, 15, 10),
+            rounded)
+
+        # round up second only
+        time_micro_up = datetime.datetime(2019, 1, 10, 5, 15, 10, 500000)
+        rounded = ph5utils.roundSeconds(time_micro_up)
+        self.assertEqual(
+            datetime.datetime(2019, 1, 10, 5, 15, 11),
+            rounded)
+
+        # round up seconds rollover
+        time_micro_up = datetime.datetime(2019, 1, 10, 5, 15, 59, 500000)
+        rounded = ph5utils.roundSeconds(time_micro_up)
+        self.assertEqual(
+            datetime.datetime(2019, 1, 10, 5, 16, 00),
+            rounded)
+
+        # round up minutes rollover
+        time_micro_up = datetime.datetime(2019, 1, 10, 5, 59, 59, 500000)
+        rounded = ph5utils.roundSeconds(time_micro_up)
+        self.assertEqual(
+            datetime.datetime(2019, 1, 10, 6, 0, 0),
+            rounded)
+
+        # round up hour rollover
+        time_micro_up = datetime.datetime(2019, 1, 10, 23, 59, 59, 500000)
+        rounded = ph5utils.roundSeconds(time_micro_up)
+        self.assertEqual(
+            datetime.datetime(2019, 1, 11, 0, 0, 0),
+            rounded)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Thank your for contributing to PH5

Before submitting a PR, please review the pull request guidelines:
https://github.com/PIC-IRIS/PH5/blob/master/CONTRIBUTING.md#submitting-a-pull-request

### What does this PR do?
Changes the naming scheme of command line output files for ph5toms to be rounded to the nearest second. This only changes the file naming not the actual time series inside the file. This was done mainly because Node instruments may not begin recording on an even second and their file name output can be hard to read with long microseconds in the name.
### Relevant Issues?
#287 

### Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
