### PR TITLE
Fix for PH5 validate incorrectly marking stations as missing data

### DIFF
--- a/ph5/core/ph5api.py
+++ b/ph5/core/ph5api.py
@@ -897,10 +897,8 @@ class PH5(experiment.ExperimentGroup):
         rows_keep = []
         rows = []
         rk = {}
-        if das not in self.Das_t_full:
-            rows, keys = self.ph5_g_receivers.read_das()
-            self.Das_t_full[das] = {'rows': rows, 'keys': keys}
-
+        rows, keys = self.ph5_g_receivers.read_das()
+        self.Das_t_full[das] = {'rows': rows, 'keys': keys}
         if stop_epoch is not None and start_epoch is not None:
             for r in self.Das_t_full[das]['rows']:
                 # Start and stop for this das event window

--- a/ph5/utilities/ph5validate.py
+++ b/ph5/utilities/ph5validate.py
@@ -479,7 +479,7 @@ class PH5Validate(object):
                          "You may need to reload the raw "
                          "data for this station."
                          .format(str(das_serial)))
-        
+
         try:
             das_rows = self.ph5.Das_t[das_serial]['rows']
             ph5api.filter_das_t(das_rows,

--- a/ph5/utilities/ph5validate.py
+++ b/ph5/utilities/ph5validate.py
@@ -473,14 +473,16 @@ class PH5Validate(object):
         if sensor_serial is None:
             warning.append("Sensor serial number is missing.")
 
+        self.ph5.read_das_t(das_serial, reread=False)
+        if das_serial not in self.ph5.Das_t:
+            error.append("No data found for das serial number {0}. "
+                         "You may need to reload the raw "
+                         "data for this station."
+                         .format(str(das_serial)))
+        
         try:
-            self.ph5.read_das_t(das_serial, reread=False)
-            if das_serial not in self.ph5.Das_t:
-                error.append("No data found for das serial number {0}. "
-                             "You may need to reload the raw "
-                             "data for this station."
-                             .format(str(das_serial)))
-            ph5api.filter_das_t(self.ph5.Das_t[das_serial]['rows'],
+            das_rows = self.ph5.Das_t[das_serial]['rows']
+            ph5api.filter_das_t(das_rows,
                                 channel_id)
             true_deploy, true_pickup =\
                 self.ph5.get_extent(das=das_serial,
@@ -495,7 +497,7 @@ class PH5Validate(object):
                 warning.append("Data exists after pickup time: "
                                + str(time) + " seconds ")
             self.ph5.forget_das_t(das_serial)
-        except BaseException:
+        except KeyError:
             try:  # avoid opening too many files
                 self.ph5.forget_das_t(das_serial)
             except Exception:


### PR DESCRIPTION
### What does this PR do?

Provides a fix for `ph5_validate` incorrectly identifying stations as missing data as well as crashing from opening too many files.

### Relevant Issues?
Issue #308 

### Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
