### PR TITLE
Autocorrect Kef file Timespans. 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
+set_deploy_times.py
+ * An optional  additional argument, --auto-correct, has been added. This argument permits the function to automatically change a .kef file's deploy times and pickup times.
+ * Times are changed to the floor and ceiling seconds that are defined by the start and end time of trace data to which the kef file refers.
 entry_points.py
- * creates a dictionary, keys are names of scripts, 
-      values are (1) simple description, 
+ * creates a dictionary, keys are names of scripts,
+      values are (1) simple description,
       (2) entry points for use by setup.
 help.py
  * calls entry_points to print the short descriptions in alpha-order.
@@ -8,11 +11,11 @@ Master:
 ph5
  * made pep8 compliant
  * update all modules to use a standardized logger (issue #213)
- * cleanup comments and remove commented out code (issue #216) 
+ * cleanup comments and remove commented out code (issue #216)
  * replace deprecated optparse with argparse module.
  * update ph5 to better install c requirements
 ph5.utilities.ph5
- * add helpfile to utilities folder. Have not added pointer in setup.py as yet. 
+ * add helpfile to utilities folder. Have not added pointer in setup.py as yet.
  * Typing ph5 shows user the choices for help information.
  * Usage: ph5 pforma (lists info about pforma)https://github.com/PIC-IRIS/PH5/pull/new/helpfile
 ph5.clients.ph5toms
@@ -225,7 +228,7 @@ v4.0.2
 
 v4.0.1
 - ph5.clients.ph5tostationxml
-  * updated to work with latest obspy response code 
+  * updated to work with latest obspy response code
 
 v4.0.0
 - Initial Release

--- a/ph5/CONTRIBUTORS.txt
+++ b/ph5/CONTRIBUTORS.txt
@@ -7,3 +7,4 @@ Jacobs, Katie
 Pacheco, Celia
 Thomas, David
 Accardo, Natalie
+Ronan, Tim

--- a/ph5/utilities/set_deploy_pickup_times.py
+++ b/ph5/utilities/set_deploy_pickup_times.py
@@ -13,7 +13,7 @@ from kef2ph5 import add_references
 from math import floor, ceil
 
 
-PROG_VERSION = '2018.268'
+PROG_VERSION = '2019.197'
 LOGGER = logging.getLogger(__name__)
 
 os.environ['TZ'] = 'UTC'


### PR DESCRIPTION
#What does this PR do?
This PR adds an optional additional argument, --auto-correct, to utilities/set_deploy_times.py. This argument permits the function to automatically change a .kef file's deploy times and pickup times to the floor and ceiling seconds that are defined by the start and end time of trace data to which the kef file refers. 

### Relevant Issues?
This code is associated with issue 310. 

### Checklist
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests pass.
- [X] Any new or changed features have are documented.
- [X] Changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
