### PR TITLE
StationXML Report Number

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,8 @@ ph5.clients.tests.test_ph5toms
 ph5.clients.ph5tostationxml
  * Limit number of asynchronous processes
  * Remove storage format from the sxml channel level to be compatible with sxml version 1.1
+ * Add a new custom iris namespace attribute called iris:PH5ReportNum to the network StationXML element
+ * Remove the report number from the alternateCode value in the network StationXML element
 ph5.utilities.ph5validate
  * add data time checking
 ph5.utilities.sort_kef_gen.py

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -504,13 +504,19 @@ class PH5toStationXMLParser(object):
         if obs_stations:
             obs_network = inventory.Network(
                 self.experiment_t[0]['net_code_s'])
-            obs_network.alternate_code = \
-                self.experiment_t[0]['experiment_id_s']
             obs_network.description = self.experiment_t[0]['longname_s']
             start_time, end_time = self.get_network_date()
             obs_network.start_date = UTCDateTime(start_time)
             obs_network.end_date = UTCDateTime(end_time)
             obs_network.total_number_of_stations = self.total_number_stations
+            extra = AttribDict({
+                    'PH5ReportNum': {
+                        'value': self.experiment_t[0]['experiment_id_s'],
+                        'namespace': self.manager.iris_custom_ns,
+                        'type': 'attribute'
+                    }
+                })
+            obs_network.extra = extra
             obs_network.stations = obs_stations
             return obs_network
         else:


### PR DESCRIPTION
## What does this PR do?
Adds a new custom iris namespace attribute called `iris:PH5ReportNum` to the network StationXML element and removes the report number from the `alternateCode` value. We are updating the PH5 Station Web Service at the DMC and this change is needed.

### Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
