### PR TITLE
Fix 310

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,11 +2,11 @@ Master:
 ph5
  * made pep8 compliant
  * update all modules to use a standardized logger (issue #213)
- * cleanup comments and remove commented out code (issue #216) 
+ * cleanup comments and remove commented out code (issue #216)
  * replace deprecated optparse with argparse module.
  * update ph5 to better install c requirements
 ph5.utilities.ph5
- * add helpfile to utilities folder. Have not added pointer in setup.py as yet. 
+ * add helpfile to utilities folder. Have not added pointer in setup.py as yet.
  * Typing ph5 shows user the choices for help information.
  * Usage: ph5 pforma (lists info about pforma)https://github.com/PIC-IRIS/PH5/pull/new/helpfile
 ph5.clients.ph5toms
@@ -76,8 +76,8 @@ ph5.core.tests.test_ph5api
 ph5.core.ph5api
  * fix ph5api cut sometimes returns too many samples (issue #298)
 ph5.entry_points
- * creates a dictionary, keys are names of scripts, 
-      values are (1) simple description, 
+ * creates a dictionary, keys are names of scripts,
+      values are (1) simple description,
       (2) entry points for use by setup.
 ph5.help
  * calls entry_points to print the short descriptions in alpha-order.
@@ -234,7 +234,10 @@ v4.0.2
 
 v4.0.1
 - ph5.clients.ph5tostationxml
-  * updated to work with latest obspy response code 
+  * updated to work with latest obspy response code
 
 v4.0.0
 - Initial Release
+-ph5.utilities.set_deploy_pickup_times.py (issue # 310)
+* Created functionality that automatically sets an output kef file's deploy and pickup times
+based on the files coorspunding time series data.

--- a/ph5/utilities/set_deploy_pickup_times.py
+++ b/ph5/utilities/set_deploy_pickup_times.py
@@ -8,8 +8,7 @@ import logging
 import time
 import re
 import datetime
-from ph5.core import timedoy, kefx, ph5api
-from kef2ph5 import add_references
+from ph5.core import timedoy, ph5api
 from math import floor, ceil
 
 
@@ -70,7 +69,6 @@ class PH5_Time(object):
 
 
 def get_args():
-    #global ARRAY_FILE, DEPLOY, PICKUP, AUTO_CORRECT, NICKNAME, PATH
     parser = argparse.ArgumentParser(
                                 formatter_class=argparse.RawTextHelpFormatter)
     parser.usage = (" set_deploy_pickup_times -a Array_t_xxx.kef "
@@ -117,7 +115,6 @@ def get_args():
 
 
 def write_timekef(fh, of, dep_time, pu_time, auto):
-
     inc = 0
     while True:
         line = fh.readline()
@@ -199,17 +196,16 @@ def write_timekef(fh, of, dep_time, pu_time, auto):
         else:
             of.write("\t%s\n" % line)
 
-def main():
-    ##global ARRAY_FILE, DEPLOY, PICKUP, AUTO_CORRECT, NICKNAME, PATH
 
+def main():
     args_list = get_args()
-    NICKNAME = args_list[0] 
-    PATH = args_list[1]  
-    ARRAY_FILE = args_list[2] 
-    DEPLOY = args_list[3]  
-    PICKUP = args_list[4]  
-    AUTO_CORRECT = args_list[5] 
-    
+    NICKNAME = args_list[0]
+    PATH = args_list[1]
+    ARRAY_FILE = args_list[2]
+    DEPLOY = args_list[3]
+    PICKUP = args_list[4]
+    AUTO_CORRECT = args_list[5]
+
     dep_time = []
     pu_time = []
     if not os.path.exists(ARRAY_FILE):
@@ -219,11 +215,11 @@ def main():
         fh = open(ARRAY_FILE)
         mdir = os.path.dirname(ARRAY_FILE)
         infile = os.path.basename(ARRAY_FILE)
-        base = 'autocortime_{0}'.format(infile)   
-        i=1
+        base = 'autocortime_{0}'.format(infile)
+        i = 1
         file_inc = True
         # increments the files names
-        while file_inc: 
+        while file_inc:
             if os.path.isfile(base):
                 base = 'autocortime{0}_{1}'.format(i, infile)
                 i = i+1
@@ -233,7 +229,7 @@ def main():
                     file_inc = False
             else:
                 file_inc = False
-      
+
         of = open(os.path.join(mdir, base), 'w+')
         # LOGGER.info("Opened: {0}".join(os.path.join(mdir, base)))
     if AUTO_CORRECT:
@@ -261,7 +257,7 @@ def main():
                                 das=station['das/serial_number_s'],
                                 component=station['channel_number_i'],
                                 sample_rate=station['sample_rate_i'])
-                        if true_deploy is None or true_pickup is None :
+                        if true_deploy is None or true_pickup is None:
                             LOGGER.warning('No DAS Table Found for %s' % das)
                             dep_time.append(None)
                             pu_time.append(None)

--- a/ph5/utilities/set_deploy_pickup_times.py
+++ b/ph5/utilities/set_deploy_pickup_times.py
@@ -116,8 +116,8 @@ def get_args():
 
 
 def barf(fh, of, dep_time, pu_time):
-    of.write("#  %s v%s %s\n" %
-             (sys.argv[0], PROG_VERSION, time.ctime(time.time())))
+    #of.write("#  %s v%s %s\n" %
+     #        (sys.argv[0], PROG_VERSION, time.ctime(time.time())))
     while True:
         line = fh.readline()
         if not line:
@@ -125,12 +125,15 @@ def barf(fh, of, dep_time, pu_time):
         line = line.strip()
         if not line:
             continue
+        if line[0:5] == '#   T':
+            of.write('\n')
+            of.write(line + '\n')
+            continue
         if line[0] == '#':
             of.write(line + '\n')
             continue
-
         if line[0] == '/':
-            of.write("%s:Update:id_s\n" % line)
+            of.write("%s\n" % line)
             continue
 
         if deployRE.match(line):
@@ -138,27 +141,27 @@ def barf(fh, of, dep_time, pu_time):
             pre, post = key.split('/')
             post = post.strip()
             if post == 'epoch_l':
-                of.write("\tdeploy_time/epoch_l = %d\n" % dep_time.epoch_l)
+                of.write("\tdeploy_time/epoch_l=%d\n" % dep_time.epoch_l)
             elif post == 'micro_seconds_i':
-                of.write("\tdeploy_time/micro_seconds_i = %d\n" %
+                of.write("\tdeploy_time/micro_seconds_i=%d\n" %
                          dep_time.micro_seconds_i)
             elif post == 'type_s':
-                of.write("\tdeploy_time/type_s = %s\n" % dep_time.type_s)
+                of.write("\tdeploy_time/type_s=%s\n" % dep_time.type_s)
             elif post == 'ascii_s':
-                of.write("\tdeploy_time/ascii_s = %s\n" % dep_time.ascii_s)
+                of.write("\tdeploy_time/ascii_s=%s\n" % dep_time.ascii_s)
         elif pickupRE.match(line):
             key, val = line.split('=')
             pre, post = key.split('/')
             post = post.strip()
             if post == 'epoch_l':
-                of.write("\tpickup_time/epoch_l = %d\n" % pu_time.epoch_l)
+                of.write("\tpickup_time/epoch_l=%d\n" % pu_time.epoch_l)
             elif post == 'micro_seconds_i':
-                of.write("\tpickup_time/micro_seconds_i = %d\n" %
+                of.write("\tpickup_time/micro_seconds_i=%d\n" %
                          pu_time.micro_seconds_i)
             elif post == 'type_s':
-                of.write("\tpickup_time/type_s = %s\n" % pu_time.type_s)
+                of.write("\tpickup_time/type_s=%s\n" % pu_time.type_s)
             elif post == 'ascii_s':
-                of.write("\tpickup_time/ascii_s = %s\n" % pu_time.ascii_s)
+                of.write("\tpickup_time/ascii_s=%s\n" % pu_time.ascii_s)
         else:
             of.write("\t%s\n" % line)
 

--- a/ph5/utilities/set_deploy_pickup_times.py
+++ b/ph5/utilities/set_deploy_pickup_times.py
@@ -115,7 +115,8 @@ def get_args():
     AUTO_CORRECT = args.auto_correct
 
 
-def barf(fh, of, dep_time, pu_time, das):
+def barf(fh, of, dep_time, pu_time, auto):
+    
     inc = 0
     while True:
         line = fh.readline()
@@ -184,7 +185,10 @@ def barf(fh, of, dep_time, pu_time, das):
                     of.write("\tpickup_time/type_s=\n")
                 else:
                     of.write("\tpickup_time/type_s=%s\n" % pu_time[inc].type_s)
-                inc = inc+1  # Increments the list of input units.
+                if auto == True:
+                    inc = inc+1  # Increments the list of input units.
+                else:
+                    inc = 0
             elif post == 'ascii_s':
                 if pu_time[inc] is None:
                     of.write("\tpickup_time/ascii_s=\n")
@@ -217,6 +221,8 @@ def main():
     global ARRAY_FILE, DEPLOY, PICKUP, AUTO_CORRECT, NICKNAME, PATH
 
     get_args()
+    dep_time = []
+    pu_time = []
     if not os.path.exists(ARRAY_FILE):
         LOGGER.error("Can't open {0}!".format(ARRAY_FILE))
         sys.exit()
@@ -228,8 +234,6 @@ def main():
         of = open(os.path.join(mdir, base), 'w+')
         # LOGGER.info("Opened: {0}".join(os.path.join(mdir, base)))
     if AUTO_CORRECT:
-        dep_time = []
-        pu_time = []
         ph5_api_object = ph5api.PH5(path=PATH, nickname=NICKNAME)
         ph5_api_object.read_array_t_names()
         if not ph5_api_object.Array_t_names:
@@ -267,11 +271,12 @@ def main():
                             .strftime('%Y:%j:%H:%M:%S'))
                         dep_time.append(PH5_Time(passcal_s=julian_tdeploy))
                         pu_time.append(PH5_Time(passcal_s=julian_tpickup))
-        barf(fh, of, dep_time, pu_time, das)
+        barf(fh, of, dep_time, pu_time, auto = True)
     else:
-        dep_time = PH5_Time(passcal_s=DEPLOY)
-        pu_time = PH5_Time(passcal_s=PICKUP)
-        barf(fh, of, dep_time, pu_time, das)
+        
+        dep_time.append(PH5_Time(passcal_s=DEPLOY))
+        pu_time.append(PH5_Time(passcal_s=PICKUP))
+        barf(fh, of, dep_time, pu_time, auto = False)
     of.close()
     fh.close()
 

--- a/ph5/utilities/set_deploy_pickup_times.py
+++ b/ph5/utilities/set_deploy_pickup_times.py
@@ -116,7 +116,7 @@ def get_args():
 
 
 def barf(fh, of, dep_time, pu_time, auto):
-    
+
     inc = 0
     while True:
         line = fh.readline()
@@ -185,7 +185,7 @@ def barf(fh, of, dep_time, pu_time, auto):
                     of.write("\tpickup_time/type_s=\n")
                 else:
                     of.write("\tpickup_time/type_s=%s\n" % pu_time[inc].type_s)
-                if auto == True:
+                if auto is True:
                     inc = inc+1  # Increments the list of input units.
                 else:
                     inc = 0
@@ -271,12 +271,11 @@ def main():
                             .strftime('%Y:%j:%H:%M:%S'))
                         dep_time.append(PH5_Time(passcal_s=julian_tdeploy))
                         pu_time.append(PH5_Time(passcal_s=julian_tpickup))
-        barf(fh, of, dep_time, pu_time, auto = True)
+        barf(fh, of, dep_time, pu_time, auto=True)
     else:
-        
         dep_time.append(PH5_Time(passcal_s=DEPLOY))
         pu_time.append(PH5_Time(passcal_s=PICKUP))
-        barf(fh, of, dep_time, pu_time, auto = False)
+        barf(fh, of, dep_time, pu_time, auto=False)
     of.close()
     fh.close()
 

--- a/ph5/utilities/set_deploy_pickup_times.py
+++ b/ph5/utilities/set_deploy_pickup_times.py
@@ -142,25 +142,25 @@ def barf(fh, of, dep_time, pu_time, auto):
             post = post.strip()
             if post == 'epoch_l':
                 if dep_time[inc] is None:
-                    of.write("\tdeploy_time/epoch_l=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tdeploy_time/epoch_l=%d\n" %
                              dep_time[inc].epoch_l)
             elif post == 'micro_seconds_i':
                 if dep_time[inc] is None:
-                    of.write("\tdeploy_time/micro_seconds_i=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tdeploy_time/micro_seconds_i=%d\n" %
                              dep_time[inc].micro_seconds_i)
             elif post == 'type_s':
                 if dep_time[inc] is None:
-                    of.write("\tdeploy_time/type_s=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tdeploy_time/type_s=%s\n" %
                              dep_time[inc].type_s)
             elif post == 'ascii_s':
                 if dep_time[inc] is None:
-                    of.write("\tdeploy_time/ascii_s=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tdeploy_time/ascii_s=%s\n" %
                              dep_time[inc].ascii_s)
@@ -170,19 +170,19 @@ def barf(fh, of, dep_time, pu_time, auto):
             post = post.strip()
             if post == 'epoch_l':
                 if pu_time[inc] is None:
-                    of.write("\tpickup_time/epoch_l=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tpickup_time/epoch_l=%d\n" %
                              pu_time[inc].epoch_l)
             elif post == 'micro_seconds_i':
                 if pu_time[inc] is None:
-                    of.write("\tpickup_time/micro_seconds_i=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tpickup_time/micro_seconds_i=%d\n" %
                              pu_time[inc].micro_seconds_i)
             elif post == 'type_s':
                 if pu_time[inc] is None:
-                    of.write("\tpickup_time/type_s=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tpickup_time/type_s=%s\n" % pu_time[inc].type_s)
                 if auto is True:
@@ -191,7 +191,7 @@ def barf(fh, of, dep_time, pu_time, auto):
                     inc = 0
             elif post == 'ascii_s':
                 if pu_time[inc] is None:
-                    of.write("\tpickup_time/ascii_s=\n")
+                    of.write("\t%s\n" % line)
                 else:
                     of.write("\tpickup_time/ascii_s=%s\n" %
                              pu_time[inc].ascii_s)


### PR DESCRIPTION
### What does this PR do?
This PR adds an optional additional argument, --auto-correct, to utilities/set_deploy_times.py. This argument permits the function to automatically change a .kef file's deploy times and pickup times to the floor and ceiling seconds that are defined by the start and end time of trace data to which the kef file refers.
Relevant Issues?

This PR is associated with issue #310 .
Please note, this PR an new instance of PR #314. Please refer to PR #314 for previous discussion on this issue.  

### Relevant Issues?
issue #310

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests pass.
- [X] Any new or changed features have are documented.
- [X] Changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
