### PR TITLE
No longer make PySide and PyQt4 mandatory for PH5 installation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,8 @@
+Master:
 ph5
  * fixed errors in entry_points.py that prevented apps from executing.
  * fixed: seg2toph5, ph5toevt. 
  * Deleted: ph5view (doesn't compile, was a W.I.P. left to wither) 
-Master:
-ph5
  * made pep8 compliant
  * update all modules to use a standardized logger (issue #213)
  * cleanup comments and remove commented out code (issue #216) 

--- a/environment.yml
+++ b/environment.yml
@@ -8,8 +8,6 @@ dependencies:
  - numpy
  - numexpr
  - pyproj
- - PySide
- - pyqt=4
  - psutil
  - obspy
  - vispy

--- a/ph5/clients/ph5view/ph5_viewer.py
+++ b/ph5/clients/ph5view/ph5_viewer.py
@@ -21,14 +21,22 @@ import os.path as path
 from vispy import gloo, visuals, app
 import matplotlib.pyplot as plt
 from copy import deepcopy
+
 LOGGER = logging.getLogger(__name__)
+
 try:
     from PyQt4 import QtGui, QtCore
     from PyQt4.QtCore import QPoint
     from PyQt4.QtGui import QColor
 except Exception:
-    LOGGER.error("PyQt4 must be installed for this to run")
-###########################################################
+    msg = ("No module named PyQt4. "
+           "Please install PyQt4 first, it is needed for ph5_viewer. "
+           "\n\n"
+           "If using Anaconda run 'conda install pyqt=4'"
+           "For pip users, PyQt4 installation instructions are available at "
+           "http://pyqt.sourceforge.net/Docs/PyQt4/installation.html.")
+    LOGGER.error(msg)
+
 VER = 201914
 if ph5_viewer_reader.VER > VER:
     VER = ph5_viewer_reader.VER

--- a/ph5/core/pmonitor.py
+++ b/ph5/core/pmonitor.py
@@ -26,14 +26,16 @@ LOGGER = logging.getLogger(__name__)
 TIMEOUT = 500 * 4
 
 try:
-    from PySide import QtGui, QtCore
-except Exception as e:
-    LOGGER.error("No PySide: {0}".format(e.message))
-    try:
-        from PyQt4 import QtGui, QtCore
-        QtCore.Signal = QtCore.pyqtSignal
-    except Exception:
-        LOGGER.error("PyQt4 or PySide required: {0}".format(e.message))
+    from PyQt4 import QtGui, QtCore
+    QtCore.Signal = QtCore.pyqtSignal
+except Exception:
+    msg = ("\n\nNo module named PyQt4. "
+           "Please install PyQt4 first, it is needed for pmonitor. "
+           "\n\n"
+           "If using Anaconda run 'conda install pyqt=4'"
+           "For pip users, PyQt4 installation instructions are available at "
+           "http://pyqt.sourceforge.net/Docs/PyQt4/installation.html.")
+    raise ImportError(msg)
 
 
 # RE to detect when a raw data file has finished loading

--- a/ph5/utilities/changes.py
+++ b/ph5/utilities/changes.py
@@ -5,10 +5,17 @@ import time
 import logging
 from ph5.core import columns
 LOGGER = logging.getLogger(__name__)
+
 try:
     from PyQt4 import QtGui, QtCore
 except Exception:
-    LOGGER.error("PyQt4 must be installed for this to run")
+    msg = ("\n\nNo module named PyQt4. "
+           "Please install PyQt4 first, it is needed for experiment_t_gen. "
+           "\n\n"
+           "If using Anaconda run 'conda install pyqt=4'"
+           "For pip users, PyQt4 installation instructions are available at "
+           "http://pyqt.sourceforge.net/Docs/PyQt4/installation.html.")
+    raise ImportError(msg)
 
 PROG_VERSION = "2016.245"
 

--- a/ph5/utilities/noven.py
+++ b/ph5/utilities/noven.py
@@ -19,7 +19,13 @@ LOGGER = logging.getLogger(__name__)
 try:
     from PyQt4 import QtGui, QtCore
 except Exception:
-    LOGGER.error("PyQt4 must be installed for this to run")
+    msg = ("\n\nNo module named PyQt4. "
+           "Please install PyQt4 first, it is needed for noven. "
+           "\n\n"
+           "If using Anaconda run 'conda install pyqt=4'"
+           "For pip users, PyQt4 installation instructions are available at "
+           "http://pyqt.sourceforge.net/Docs/PyQt4/installation.html.")
+    raise ImportError(msg)
 
 RECEIVER_CFG_S = '{\n'\
     '   "description_s": {\n'\

--- a/ph5/utilities/pformagui.py
+++ b/ph5/utilities/pformagui.py
@@ -15,7 +15,13 @@ LOGGER = logging.getLogger(__name__)
 try:
     from PySide import QtCore, QtGui
 except Exception:
-    LOGGER.error("PySide must be installed for this to run")
+    msg = ("\n\nNo module named PySide. "
+           "Please install PySide first, it is needed for pforma. "
+           "\n\n"
+           "If using Anaconda run 'conda install PySide'"
+           "For pip users, PySide installation instructions are available at "
+           "https://pypi.org/project/PySide/#installation.")
+    raise ImportError(msg)
 
 UTMZone = '13N'
 

--- a/setup.py
+++ b/setup.py
@@ -26,28 +26,6 @@ except ImportError:
     pass
 
 try:
-    import PyQt4
-except ImportError:
-    msg = ("No module named PyQt4. "
-           "Please install PyQt4 first, it is needed before installing PH5. "
-           "\n\n"
-           "If using Anaconda run 'conda install pyqt=4'"
-           "For pip users, PyQt4 installation instructions are available at "
-           "http://pyqt.sourceforge.net/Docs/PyQt4/installation.html.")
-    raise ImportError(msg)
-
-try:
-    import PySide
-except ImportError:
-    msg = ("No module named PySide. "
-           "Please install PySide first, it is needed before installing PH5. "
-           "\n\n"
-           "If using Anaconda run 'conda install PySide'"
-           "For pip users, PySide installation instructions are available at "
-           "https://pypi.org/project/PySide/#installation.")
-    raise ImportError(msg)
-
-try:
     import numpy  # @UnusedImport # NOQA
 except ImportError:
     msg = ("No module named numpy. "
@@ -86,9 +64,6 @@ setup(
                       'tables',
                       'matplotlib<2',
                       'subprocess32'
-                      # pyicu - seems to work without
-                      # pyqt4 - required external program
-                      # PySide - required external program
                      ],
     classifiers=[
         # How mature is this project? Common values are


### PR DESCRIPTION

### What does this PR do?
Adds to PR #326 . Removed mandatory requirement for PySide and PyQt4. These are now only required for running the GUI applications pforma, experiment_t_gen, and noven.

### Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
