### PR TITLE
WIP: fixing segy2ph5 errors

### DIFF
--- a/ph5/core/segyreader.py
+++ b/ph5/core/segyreader.py
@@ -196,7 +196,7 @@ class Reader ():
         buf = self.read_buf(3200)
         t = segy_h.Text()
 
-        t.parse(buf)
+        container = t.parse(buf)
 
         keys = segy_h.Text().__keys__
 
@@ -249,7 +249,7 @@ class Reader ():
         b = segy_h.Reel(self.endianess)
 
         ret = {}
-        b.parse(buf)
+        container = b.parse(buf)  # dthomas added 'container'
 
         keys = segy_h.Reel().__keys__
         for k in keys:
@@ -265,7 +265,7 @@ class Reader ():
         t = segy_h.Trace(self.endianess)
 
         ret = {}
-        t.parse(buf)
+        container = t.parse(buf)  # dthomas added 'container'
 
         keys = segy_h.Trace().__keys__
         for k in keys:
@@ -296,7 +296,7 @@ class Reader ():
             e = segy_h.iNova(self.endianess)
             keys = segy_h.iNova().__keys__
 
-        e.parse(buf)
+        container = e.parse(buf)  # dthomas added 'container'
 
         for k in keys:
             what = "container.{0}".format(k)

--- a/ph5/utilities/segy2ph5.py
+++ b/ph5/utilities/segy2ph5.py
@@ -857,9 +857,9 @@ def process_trace(th, bh, rh, eh, tr):
         EXREC.ph5_g_maps.newdas('Das_g_', Das)
         p_das_t['array_name_log_a'] = EXREC.ph5_g_receivers.nextarray('Log_a_')
         p_das_t['response_table_n_i'] = n_i
-
+        print "rh:", rh
         year = rh['year']
-        doy = rh['day']
+        doy = rh['day']  # xxx, doy needed (Julian), but is not in rh[].
         hour = rh['hour']
         minute = rh['minute']
         seconds = rh['second']


### PR DESCRIPTION
### What does this PR do?
Provides a workspace for addressing why segy to ph5 conversion is not working.

Some background: segy2ph5.py was started by Steve Azevedo, but never was finished. Alissa says someone has been hired at the DMC to process old segy files into ph5 archives, and that's why this unfinished project is needing some attention soon.

### Relevant Issues?
#335 

### Status
This surfaced when Alissa tried to get a known, vetted segy file into a ph5 archive.
The file is available at https://www.passcal.nmt.edu/~dthomas/bugfiles/, and is called Hansel_Valley_geo.segy. As discussed in #335, the container vars were not being filled. Once that was fixed in 4 places in ph5.core.segyreader.py, execution proceeds unto the Julian day is needed for a header, but is not defined, causing a crash.

### Checklist
- [ ] All tests pass. No, this is a WIP.
- [ ] Any new or changed features have are documented. Pending.
- [ ] Changes have been added to `CHANGELOG.txt` . Pending.
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
