### PR TITLE
Bug fixes for ph5toms and ph5tostationxml

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,11 +17,12 @@ ph5.clients.ph5toms
  * add day volume cuts
  * add cut length to ph5toms for webservices
  * Fix bug causing duplicate data to be written (issue #264)
- * FIx bug causing data to not be written in special cases at the start of the data in PH5
+ * Fix bug causing data to not be written in special cases at the start of the data in PH5
  * Slight change to naming output on command line for more consistency
  * No longer adds extra sample at end of cut
  * Fix substring issue
  * Add ph5toms support for the web service SEG-Y timeseries data format.
+ * Fix bug where starttime offset was applied after calculating the end time of a shot gather request
 ph5.utilities.report_gen
  * add report_gen entry point to setup.py
 ph5.utilities.pformagui
@@ -41,6 +42,8 @@ ph5.clients.ph5tostationxml
  * ph5tostationxml now correctly handles stations with multiple deployments (issue #318)
  * Add a new custom iris namespace attribute called iris:PH5ReportNum to the network StationXML element
  * Remove the report number from the alternateCode value in the network StationXML element
+ * Round latitude and longitude to 6 decimal places in stationxml to match SEED maximum
+ * Round elevation to 1 decimal place in stationxml to match SEED maximum
 ph5.utilities.ph5validate
  * add data time checking
 ph5.utilities.sort_kef_gen.py

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -692,6 +692,9 @@ class PH5toMSeed(object):
         for sct in station_cut_times:
             start_fepoch = sct.time
             if self.reqtype == "SHOT":
+                if self.offset:
+                    # adjust starttime by an offset
+                    start_fepoch += int(self.offset)
                 if self.length:
                     stop_fepoch = start_fepoch + self.length
                 else:
@@ -736,10 +739,6 @@ class PH5toMSeed(object):
             start_passcal = epoch2passcal(start_fepoch, sep=':')
             start_passcal_list = start_passcal.split(":")
             start_doy = start_passcal_list[1]
-
-            if self.offset:
-                # adjust starttime by an offset
-                start_fepoch += int(self.offset)
 
             if self.doy_keep:
                 if start_doy not in self.doy:

--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -527,12 +527,13 @@ class PH5toStationXMLParser(object):
                            sta_latitude, sta_elevation, creation_date,
                            termination_date, site_name):
         obs_station = inventory.Station(sta_code,
-                                        latitude=sta_latitude,
-                                        longitude=sta_longitude,
+                                        latitude=round(sta_latitude, 6),
+                                        longitude=round(sta_longitude, 6),
                                         start_date=start_date,
                                         end_date=end_date,
-                                        elevation=sta_elevation)
-        obs_station.site = inventory.Site(name=site_name)
+                                        elevation=round(sta_elevation, 1))
+        obs_station.site = inventory.Site(name=(site_name if site_name
+                                                else sta_code))
         obs_station.creation_date = creation_date
         obs_station.termination_date = termination_date
         obs_station.total_number_of_channels = 0  # initialized to 0
@@ -552,9 +553,9 @@ class PH5toStationXMLParser(object):
         obs_channel = inventory.Channel(
                                         code=cha_code,
                                         location_code=loc_code,
-                                        latitude=cha_latitude,
-                                        longitude=cha_longitude,
-                                        elevation=cha_elevation,
+                                        latitude=round(cha_latitude, 6),
+                                        longitude=round(cha_longitude, 6),
+                                        elevation=round(cha_elevation, 1),
                                         depth=0
                                             )
         obs_channel.start_date = start_date


### PR DESCRIPTION
## What does this PR do?
This PR contains a handful of small but important bug fixes to the `ph5toms` and `ph5tostationxml` clients

- Round latitude and longitude to 6 decimal places in stationxml to match SEED maximum
- Round elevation to 1 decimal place in stationxml to match SEED maximum
- Fix bug where starttime offset was applied after calculating the end time of a shot gather request

### Checklist
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
