### PR TITLE
Add web service support for reciever gathers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ ph5.clients.ph5toms
  * Fix substring issue
  * Add ph5toms support for the web service SEG-Y timeseries data format.
  * Fix bug where starttime offset was applied after calculating the end time of a shot gather request
+ * Add web service hooks for reciever gather request type
 ph5.utilities.report_gen
  * add report_gen entry point to setup.py
 ph5.utilities.pformagui

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -926,7 +926,8 @@ class PH5toMSeed(object):
                                                                 seed_station):
                                 continue
 
-                        if self.reqtype == "SHOT" or self.reqtype == "RECEIVER":
+                        if (self.reqtype == "SHOT" or
+                                self.reqtype == "RECEIVER"):
                             # request by shot
                             for shotline in matched_shot_lines:
                                 for shot in matched_shots:

--- a/ph5/clients/ph5toms.py
+++ b/ph5/clients/ph5toms.py
@@ -142,7 +142,7 @@ class PH5toMSeed(object):
         if not self.ph5.Experiment_t:
             self.ph5.read_experiment_t()
 
-        if self.reqtype == "SHOT":
+        if self.reqtype == "SHOT" or self.reqtype == "RECEIVER":
             self.ph5.read_event_t_names()
 
         if not self.stream and not os.path.exists(self.out_dir):
@@ -691,10 +691,11 @@ class PH5toMSeed(object):
 
         for sct in station_cut_times:
             start_fepoch = sct.time
-            if self.reqtype == "SHOT":
+            if self.reqtype == "SHOT" or self.reqtype == "RECEIVER":
                 if self.offset:
                     # adjust starttime by an offset
                     start_fepoch += int(self.offset)
+
                 if self.length:
                     stop_fepoch = start_fepoch + self.length
                 else:
@@ -858,9 +859,9 @@ class PH5toMSeed(object):
         array_names = sorted(self.ph5.Array_t_names)
         self.read_events(None)
 
-        if self.reqtype == "SHOT":
+        if self.reqtype == "SHOT" or self.reqtype == "RECEIVER":
             # create list of all matched shotlines and shot-ids for request by
-            # shot
+            # shot or receiver
             shot_lines = sorted(self.ph5.Event_t_names)
             matched_shot_lines = []
             matched_shots = []
@@ -925,7 +926,7 @@ class PH5toMSeed(object):
                                                                 seed_station):
                                 continue
 
-                        if self.reqtype == "SHOT":
+                        if self.reqtype == "SHOT" or self.reqtype == "RECEIVER":
                             # request by shot
                             for shotline in matched_shot_lines:
                                 for shot in matched_shots:
@@ -1153,9 +1154,10 @@ def main():
     args.format = args.format.upper()
 
     try:
-        if args.reqtype != "SHOT" and args.reqtype != "FDSN":
+        if args.reqtype != "SHOT" and args.reqtype != "FDSN" and \
+                args.reqtype != "RECEIVER":
             raise PH5toMSAPIError("Error - Invalid request type {0}. "
-                                  "Choose from FDSN or SHOT."
+                                  "Choose from FDSN, SHOT, or RECEIVER."
                                   .format(args.reqtype))
 
         if args.format != "MSEED" and args.format != "SAC":


### PR DESCRIPTION
## What does this PR do?

Adds hooks for ph5ws-dataselect receiver gather requests. Nothing major changed, just support for an additional request type.

### Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
