### PR TITLE
Add ph5availability entry point

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,8 @@ ph5.clients.ph5tostationxml
  * Remove the report number from the alternateCode value in the network StationXML element
  * Round latitude and longitude to 6 decimal places in stationxml to match SEED maximum
  * Round elevation to 1 decimal place in stationxml to match SEED maximum
+ ph5.clients.ph5availability
+ * New client for returning timeseries availability information
 ph5.utilities.ph5validate
  * add data time checking
 ph5.utilities.sort_kef_gen.py

--- a/ph5/entry_points.py
+++ b/ph5/entry_points.py
@@ -272,5 +272,10 @@ class CommandList():
                            'ph5.clients.ph5tostationxml:main',
                            'Takes PH5 files and returns StationXML.',
                            type=EntryPointTypes.CLIENT),
+                EntryPoint('ph5availability',
+                           'ph5.clients.ph5availability:main',
+                           'Takes PH5 files and returns time series '
+                           'availability info.',
+                           type=EntryPointTypes.CLIENT),
                 ]
             }


### PR DESCRIPTION
### What does this PR do?
Fix for #366. Adds entry point for the ph5availability service
### Relevant Issues?
#366 
### Checklist
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
