### PR TITLE
Increase the max number of records read by kef2ph5

### DIFF
--- a/ph5/utilities/kef2ph5.py
+++ b/ph5/utilities/kef2ph5.py
@@ -82,7 +82,7 @@ def populateTables():
     k.open()
 
     while True:
-        n = k.read(10000)
+        n = k.read(1000000)
         if n == 0:
             err = "Empty kef file."
             break


### PR DESCRIPTION
`kef2ph5` would fail if a file contained more than 10,000 records. 

### What does this PR do?
Increase the number of records that keftoph5 reads.

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
