### PR TITLE
Apply testfixtures

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -78,9 +78,9 @@ ph5.utilities.obspytoph5
 ph5.utilities.metadatatoph5
  * new tool for loading stationxml and dataless SEED
 ph5.utilities.tests.test_metadatatoph5
- * unit tests for metadatatoph5; Stop sending log to screen;
+ * unit tests for metadatatoph5; Stop sending log to screen; Apply tmpdir from test_base
 ph5.utilities.tests.test_obspytoph5
- * unit tests for obspytoph5; Stop sending log to screen;
+ * unit tests for obspytoph5; Stop sending log to screen; Apply tmpdir from test_base
 ph5.core.tests.test_ph5api
  * unit tests for ph5api; Stop sending log to screen;
 ph5.core.ph5api

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -80,7 +80,7 @@ ph5.utilities.metadatatoph5
 ph5.utilities.tests.test_metadatatoph5
  * unit tests for metadatatoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output; Use os.path.join for path
 ph5.utilities.tests.test_obspytoph5
- * unit tests for obspytoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output; Use os.path.join for path except for path to miniseed because data_t's raw_file_name_s will truncate the path that's longer than 32
+ * unit tests for obspytoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output; Use os.path.join for path
 ph5.core.tests.test_ph5api
  * unit tests for ph5api; Stop sending log to screen;
 ph5.core.ph5api
@@ -94,8 +94,8 @@ ph5.help
 environment.yml
  * removed unused dependencies and added pykml as a dependency
 ph5.core.test.test_base
- * use TempDirTestCase to handle temporary dictionary that keeps ph5 and log files created in unittests, this dictionary will be : deleted if test successful, remained if test failed
- * use LogTestCase to dissable log to be written to console in unittests, remove all handlers created in unittest except the one to capture log messages
+ * use TempDirTestCase to handle temporary directory that keeps ph5 and log files created in unittests, this directory will be deleted if test successful or remained if test failed
+ * use LogTestCase to disable log to be written to console in unittests, remove all handlers created in unittests except the one to capture log messages
  * add initialize_ex for creating ph5 experiment object
 ph5.clients.test.test_ph5availability
  * Unittest: Stop sending log to screen; Apply testfixtures to capture output and log; Apply tmpdir from test_base; Use os.path.join for path

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -78,9 +78,9 @@ ph5.utilities.obspytoph5
 ph5.utilities.metadatatoph5
  * new tool for loading stationxml and dataless SEED
 ph5.utilities.tests.test_metadatatoph5
- * unit tests for metadatatoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output
+ * unit tests for metadatatoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output; Use os.path.join for path
 ph5.utilities.tests.test_obspytoph5
- * unit tests for obspytoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output
+ * unit tests for obspytoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output; Use os.path.join for path except for path to miniseed because data_t's raw_file_name_s will truncate the path that's longer than 32
 ph5.core.tests.test_ph5api
  * unit tests for ph5api; Stop sending log to screen;
 ph5.core.ph5api
@@ -93,15 +93,14 @@ ph5.help
  * calls entry_points to print the short descriptions in alpha-order.
 environment.yml
  * removed unused dependencies and added pykml as a dependency
- * add testfixtures to capture log/output in unittest
 ph5.core.test.test_base
- * use TempDirTestCase to handle temporary dictionary that keeps ph5 and log files created in unittests
+ * use TempDirTestCase to handle temporary dictionary that keeps ph5 and log files created in unittests, this dictionary will be : deleted if test successful, remained if test failed
  * use LogTestCase to dissable log to be written to console in unittests, remove all handlers created in unittest except the one to capture log messages
  * add initialize_ex for creating ph5 experiment object
 ph5.clients.test.test_ph5availability
- * Unittest: Stop sending log to screen; Apply testfixtures to capture output and log; Apply tmpdir from test_base
+ * Unittest: Stop sending log to screen; Apply testfixtures to capture output and log; Apply tmpdir from test_base; Use os.path.join for path
 ph5.core.tests.test_segd2ph5
- * Unittest: Stop sending log to screen; Apply tmpdir from test_base;
+ * Unittest: Stop sending log to screen; Apply tmpdir from test_base; Use os.path.join for path
 
 v4.1.2:
 ph5.utilities.ph5validate

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -78,9 +78,9 @@ ph5.utilities.obspytoph5
 ph5.utilities.metadatatoph5
  * new tool for loading stationxml and dataless SEED
 ph5.utilities.tests.test_metadatatoph5
- * unit tests for metadatatoph5; Stop sending log to screen; Apply tmpdir from test_base
+ * unit tests for metadatatoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output
 ph5.utilities.tests.test_obspytoph5
- * unit tests for obspytoph5; Stop sending log to screen; Apply tmpdir from test_base
+ * unit tests for obspytoph5; Stop sending log to screen; Apply tmpdir from test_base; Use testfixture to capture output
 ph5.core.tests.test_ph5api
  * unit tests for ph5api; Stop sending log to screen;
 ph5.core.ph5api
@@ -95,15 +95,13 @@ environment.yml
  * removed unused dependencies and added pykml as a dependency
  * add testfixtures to capture log/output in unittest
 ph5.core.test.test_base
- * add TempDirTestCase to handle temporary dictionary that keeps ph5 and log files for unittests
- * allow log to be propagated to higger loggers
- * dissable log to be written to console in tests
- * apply above in class LogTestCase so any test want to apply the above can extend this
+ * use TempDirTestCase to handle temporary dictionary that keeps ph5 and log files created in unittests
+ * use LogTestCase to dissable log to be written to console in unittests, remove all handlers created in unittest except the one to capture log messages
  * add initialize_ex for creating ph5 experiment object
 ph5.clients.test.test_ph5availability
- * Unittest: Stop sending log to screen; Apply testfixtures;
+ * Unittest: Stop sending log to screen; Apply testfixtures to capture output and log; Apply tmpdir from test_base
 ph5.core.tests.test_segd2ph5
- * Unittest: Stop sending log to screen
+ * Unittest: Stop sending log to screen; Apply tmpdir from test_base;
 
 v4.1.2:
 ph5.utilities.ph5validate

--- a/ph5/clients/ph5availability.py
+++ b/ph5/clients/ph5availability.py
@@ -1109,13 +1109,14 @@ def main():
 
         availability.process_all()
 
-        ph5API_object.close()
     except ph5api.APIError as err:
-        LOGGER.error(err)
+        LOGGER.error(err.msg)
     except PH5AvailabilityError as err:
-        LOGGER.error(err)
+        LOGGER.error(str(err))
     except Exception as err:
-        LOGGER.error(err)
+        LOGGER.error(str(err))
+
+    ph5API_object.close()
 
 
 if __name__ == '__main__':

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -1733,7 +1733,6 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         with open('test', 'r') as content_file:
             content = content_file.read().strip()
         self.assertEqual(content, "this is a text line")
-        os.remove('test')
 
     def test_get_geoCSV_report(self):
         """

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -61,11 +61,12 @@ def checkFieldsMatch(fieldNames, fieldsList, dictList):
     return True
 
 
-class TestSegDtoPH5(LogTestCase):
+class TestPH5Availability(LogTestCase):
     def setUp(self):
         """
         setup for tests
         """
+        super(TestPH5Availability, self).setUp()
         self.ph5_object = ph5api.PH5(
             path='ph5/test_data/ph5',
             nickname='master.ph5')
@@ -1842,6 +1843,7 @@ class TestSegDtoPH5(LogTestCase):
         teardown for tests
         """
         self.ph5_object.close()
+        super(TestPH5Availability, self).tearDown()
 
 
 if __name__ == "__main__":

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -993,8 +993,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data station with data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0', '--station',
+                    self.ph5test_path, '-a', '0', '--station',
                     '500', '--channel', 'DP1']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1005,8 +1004,8 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # expect to return True 3 times, once for each channel
         # master_PH5_file without extension
         testargs = ['ph5availability', '-n', 'master', '-p',
-                    self.ph5test_path,
-                    '-a', '0', '--station', '500', '--channel', '*']
+                    self.ph5test_path, '-a', '0', '--station',
+                    '500', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1014,8 +1013,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data station with no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0', '--station',
+                    self.ph5test_path, '-a', '0', '--station',
                     '9576', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1024,8 +1022,8 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data station list data, no data,
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0', '--station', '9001,91234', '--channel', '*']
+                    self.ph5test_path, '-a', '0', '--station',
+                    '9001,91234', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1033,8 +1031,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with start time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0', '-s',
+                    self.ph5test_path, '-a', '0', '-s',
                     '2017-08-09T16:00:00.380000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1043,8 +1040,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with end time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0', '-e',
+                    self.ph5test_path, '-a', '0', '-e',
                     '2019-02-22T15:43:09.000000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1053,8 +1049,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with time range having data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0',
+                    self.ph5test_path, '-a', '0',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1064,8 +1059,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with time range having no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0',
+                    self.ph5test_path, '-a', '0',
                     '-s', '2017-08-09T16:01:01.0',
                     '-e', '2018-12-17T22:20:30.0', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1074,8 +1068,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                 out.compare('False')
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '0', '-A', '2']
+                    self.ph5test_path, '-a', '0', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1084,19 +1077,16 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_slc with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '1', '--station', '0407']
+                    self.ph5test_path, '-a', '1', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
-
                 out.compare("[('0407', '', 'HHN'), ('0407', '', 'LHN'), "
                             "('0407', '', 'LOG')]")
 
         # test get_slc with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '1', '-c', 'LOG']
+                    self.ph5test_path, '-a', '1', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1104,8 +1094,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_slc with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '1',
+                    self.ph5test_path, '-a', '1',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000']
         with patch.object(sys, 'argv', testargs):
@@ -1115,8 +1104,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_slc with array
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '1', '-A', '2']
+                    self.ph5test_path, '-a', '1', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1125,8 +1113,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_availability with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '2', '--station', '0407']
+                    self.ph5test_path, '-a', '2', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1142,8 +1129,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '2', '-c', 'LOG']
+                    self.ph5test_path, '-a', '2', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1155,8 +1141,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '2',
+                    self.ph5test_path, '-a', '2',
                     '-s', '2018-12-17T23:10:05.0',
                     '-e', '2019-02-22T15:39:03.1']
         with patch.object(sys, 'argv', testargs):
@@ -1171,8 +1156,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                     " 2019-02-22T15:39:03.099999Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '2', '-A', '4']
+                    self.ph5test_path, '-a', '2', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1185,8 +1169,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_extent with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '--station', '9001']
+                    self.ph5test_path, '-a', '3', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1200,8 +1183,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # if wrong format is stated, still print out tuple result with
         # a warning
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '-c', 'DP2', '-F', 'k']
+                    self.ph5test_path, '-a', '3', '-c', 'DP2', '-F', 'k']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1210,8 +1192,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_extent with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '-S',
+                    self.ph5test_path, '-a', '3', '-S',
                     '-s', '2019-02-22T15:39:04.1',
                     '-e', '2019-02-22T15:39:07.1']
         with patch.object(sys, 'argv', testargs):
@@ -1225,8 +1206,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_extent with wildcard station, location, channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3',
+                    self.ph5test_path, '-a', '3',
                     '--station', '?001', '-l', '*', '-c', 'DP?']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1238,8 +1218,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                     " 2019-02-22T15:43:09.000000Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '-A', '4']
+                    self.ph5test_path, '-a', '3', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1252,8 +1231,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_percentage with station, no channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '4', '--station', '9001']
+                    self.ph5test_path, '-a', '4', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 with LogCapture() as log:
@@ -1265,8 +1243,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                                      "providing exact station/channel.")
         # test get_availability_percentage with channel, no station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '4', '-c', 'DP2']
+                    self.ph5test_path, '-a', '4', '-c', 'DP2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 with LogCapture() as log:
@@ -1279,8 +1256,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '4', '-c', 'DP2',
+                    self.ph5test_path, '-a', '4', '-c', 'DP2',
                     '--station', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1294,8 +1270,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '4', '-c', 'DP1',
+                    self.ph5test_path, '-a', '4', '-c', 'DP1',
                     '--station', '500']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1304,8 +1279,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_percentage with station, channel, time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '4', '--station', '9001',
+                    self.ph5test_path, '-a', '4', '--station', '9001',
                     '-s', '2019-02-22T15:39:03.0', '-c', 'DPZ',
                     '-e', '2019-02-22T15:40:03.0']
         with patch.object(sys, 'argv', testargs):
@@ -1315,8 +1289,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # test get_availability_percentage with station, channel, time, and
         # array not match with other parameters
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '4', '-A', '3',
+                    self.ph5test_path, '-a', '4', '-A', '3',
                     '--station', '0407', '-c', 'HHN']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1328,8 +1301,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # should return 10 channels
         # should match slc_full.txt from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3',
+                    self.ph5test_path, '-a', '3',
                     '-F', 't', '-S']
         with open(os.path.join(self.home,
                                'ph5/test_data/metadata/extent_full.txt'),
@@ -1344,8 +1316,8 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # should return 10 channels
         # should match slc_full_geocsv.csv from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '-F', 'g', '-S']
+                    self.ph5test_path, '-a', '3',
+                    '-F', 'g', '-S']
         with open(os.path.join(self.home,
                                'ph5/test_data/metadata/extent_full.csv'),
                   'r') as content_file:
@@ -1357,8 +1329,8 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test extent and text format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '-F', 't', '-S']
+                    self.ph5test_path, '-a', '3',
+                    '-F', 't', '-S']
         with open(os.path.join(self.home,
                                'ph5/test_data/metadata/extent_full.txt'),
                   'r') as content_file:
@@ -1371,8 +1343,8 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.maxDiff = None
         # test extent and sync format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '-F', 's', '-S']
+                    self.ph5test_path, '-a', '3',
+                    '-F', 's', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1389,8 +1361,8 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test extent and json format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    self.ph5test_path,
-                    '-a', '3', '-F', 'j', '-S']
+                    self.ph5test_path, '-a', '3',
+                    '-F', 'j', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -9,7 +9,7 @@ import sys
 import os
 from mock import patch
 from testfixtures import OutputCapture, LogCapture
-from ph5.core.tests.test_base import LogTestCase
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase
 
 
 def checkTupleAlmostEqualIn(tup, tupList, place):
@@ -61,17 +61,25 @@ def checkFieldsMatch(fieldNames, fieldsList, dictList):
     return True
 
 
-class TestPH5Availability(LogTestCase):
+class TestPH5Availability(TempDirTestCase, LogTestCase):
     def setUp(self):
         """
         setup for tests
         """
         super(TestPH5Availability, self).setUp()
+
         self.ph5_object = ph5api.PH5(
-            path='ph5/test_data/ph5',
+            path=os.path.join(self.home, 'ph5/test_data/ph5'),
             nickname='master.ph5')
         self.availability = ph5availability.PH5Availability(
             self.ph5_object)
+
+    def tearDown(self):
+        """
+        teardown for tests
+        """
+        self.ph5_object.close()
+        super(TestPH5Availability, self).tearDown()
 
     def test_get_slc(self):
         """
@@ -1014,7 +1022,8 @@ class TestPH5Availability(LogTestCase):
 
         # test has_data station with data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0', '--station',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0', '--station',
                     '500', '--channel', 'DP1']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1025,8 +1034,8 @@ class TestPH5Availability(LogTestCase):
         # expect to return True 3 times, once for each channel
         # master_PH5_file without extension
         testargs = ['ph5availability', '-n', 'master', '-p',
-                    'ph5/test_data/ph5', '-a', '0', '--station',
-                    '500', '--channel', '*']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0', '--station', '500', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1034,7 +1043,8 @@ class TestPH5Availability(LogTestCase):
 
         # test has_data station with no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0', '--station',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0', '--station',
                     '9576', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1043,8 +1053,8 @@ class TestPH5Availability(LogTestCase):
 
         # test has_data station list data, no data,
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0', '--station',
-                    '9001,91234', '--channel', '*']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0', '--station', '9001,91234', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1052,7 +1062,8 @@ class TestPH5Availability(LogTestCase):
 
         # test has_data with start time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0', '-s',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0', '-s',
                     '2017-08-09T16:00:00.380000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1061,7 +1072,8 @@ class TestPH5Availability(LogTestCase):
 
         # test has_data with end time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0', '-e',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0', '-e',
                     '2019-02-22T15:43:09.000000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1070,7 +1082,8 @@ class TestPH5Availability(LogTestCase):
 
         # test has_data with time range having data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1080,7 +1093,8 @@ class TestPH5Availability(LogTestCase):
 
         # test has_data with time range having no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0',
                     '-s', '2017-08-09T16:01:01.0',
                     '-e', '2018-12-17T22:20:30.0', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1089,7 +1103,8 @@ class TestPH5Availability(LogTestCase):
                 out.compare('False')
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '0', '-A', '2']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '0', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1098,7 +1113,8 @@ class TestPH5Availability(LogTestCase):
         # ------------------------------------------------------------ #
         # test get_slc with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '1', '--station', '0407']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '1', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1108,7 +1124,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_slc with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '1', '-c', 'LOG']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '1', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1116,7 +1133,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_slc with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '1',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '1',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000']
         with patch.object(sys, 'argv', testargs):
@@ -1126,7 +1144,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_slc with array
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '1', '-A', '2']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '1', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1135,7 +1154,8 @@ class TestPH5Availability(LogTestCase):
         # ------------------------------------------------------------ #
         # test get_availability with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '2', '--station', '0407']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '2', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1151,7 +1171,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '2', '-c', 'LOG']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '2', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1163,7 +1184,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '2',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '2',
                     '-s', '2018-12-17T23:10:05.0',
                     '-e', '2019-02-22T15:39:03.1']
         with patch.object(sys, 'argv', testargs):
@@ -1178,7 +1200,8 @@ class TestPH5Availability(LogTestCase):
                     " 2019-02-22T15:39:03.099999Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '2', '-A', '4']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '2', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1191,7 +1214,8 @@ class TestPH5Availability(LogTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_extent with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3', '--station', '9001']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1205,7 +1229,8 @@ class TestPH5Availability(LogTestCase):
         # if wrong format is stated, still print out tuple result with
         # a warning
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3', '-c', 'DP2', '-F', 'k']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '-c', 'DP2', '-F', 'k']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1214,7 +1239,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability_extent with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3', '-S',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '-S',
                     '-s', '2019-02-22T15:39:04.1',
                     '-e', '2019-02-22T15:39:07.1']
         with patch.object(sys, 'argv', testargs):
@@ -1228,7 +1254,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability_extent with wildcard station, location, channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3',
                     '--station', '?001', '-l', '*', '-c', 'DP?']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1240,7 +1267,8 @@ class TestPH5Availability(LogTestCase):
                     " 2019-02-22T15:43:09.000000Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3', '-A', '4']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1253,7 +1281,8 @@ class TestPH5Availability(LogTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_percentage with station, no channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '4', '--station', '9001']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '4', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1261,7 +1290,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability_percentage with channel, no station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '4', '-c', 'DP2']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '4', '-c', 'DP2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1269,7 +1299,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '4', '-c', 'DP2',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '4', '-c', 'DP2',
                     '--station', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1278,7 +1309,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '4', '-c', 'DP1',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '4', '-c', 'DP1',
                     '--station', '500']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1287,7 +1319,8 @@ class TestPH5Availability(LogTestCase):
 
         # test get_availability_percentage with station, channel, time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '4', '--station', '9001',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '4', '--station', '9001',
                     '-s', '2019-02-22T15:39:03.0', '-c', 'DPZ',
                     '-e', '2019-02-22T15:40:03.0']
         with patch.object(sys, 'argv', testargs):
@@ -1297,7 +1330,8 @@ class TestPH5Availability(LogTestCase):
         # test get_availability_percentage with station, channel, time, and
         # array not match with other parameters
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '4', '-A', '3',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '4', '-A', '3',
                     '--station', '0407', '-c', 'HHN']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1309,10 +1343,12 @@ class TestPH5Availability(LogTestCase):
         # should return 10 channels
         # should match slc_full.txt from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3',
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3',
                     '-F', 't', '-S']
-        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.txt'),
+                  'r') as content_file:
             content = content_file.read().strip()
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1323,10 +1359,11 @@ class TestPH5Availability(LogTestCase):
         # should return 10 channels
         # should match slc_full_geocsv.csv from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3',
-                    '-F', 'g', '-S']
-        with open('ph5/test_data/metadata/extent_full.csv', 'r') as \
-                content_file:
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '-F', 'g', '-S']
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.csv'),
+                  'r') as content_file:
             content = content_file.read().strip()
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1335,10 +1372,11 @@ class TestPH5Availability(LogTestCase):
 
         # test extent and text format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3',
-                    '-F', 't', '-S']
-        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
-                content_file:
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '-F', 't', '-S']
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.txt'),
+                  'r') as content_file:
             content = content_file.read().strip()
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1348,16 +1386,17 @@ class TestPH5Availability(LogTestCase):
         self.maxDiff = None
         # test extent and sync format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3',
-                    '-F', 's', '-S']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '-F', 's', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
                 output = out.captured.strip()
 
         i1 = output.find('\n')
-        with open('ph5/test_data/metadata/extent_full.sync', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.sync'),
+                  'r') as content_file:
             content = content_file.read().strip()
 
         i2 = content.find('\n')
@@ -1365,15 +1404,16 @@ class TestPH5Availability(LogTestCase):
 
         # test extent and json format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    'ph5/test_data/ph5', '-a', '3',
-                    '-F', 'j', '-S']
+                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    '-a', '3', '-F', 'j', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
                 output = out.captured.strip()
         i1 = output.find('"datasources"')
-        with open('ph5/test_data/metadata/extent_full.json', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.json'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(output[i1:], content[i2:])
@@ -1654,8 +1694,9 @@ class TestPH5Availability(LogTestCase):
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_text_report(result).strip()
-        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.txt'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1663,16 +1704,18 @@ class TestPH5Availability(LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1,
             include_sample_rate=True)
         ret = self.availability.get_text_report(result).strip()
-        with open('ph5/test_data/metadata/avail_time.txt', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time.txt'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         result = self.availability.get_availability(
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_text_report(result).strip()
-        with open('ph5/test_data/metadata/avail_time_noSR.txt', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time_noSR.txt'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1699,8 +1742,9 @@ class TestPH5Availability(LogTestCase):
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_geoCSV_report(result).strip()
-        with open('ph5/test_data/metadata/extent_full.csv', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.csv'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1708,16 +1752,18 @@ class TestPH5Availability(LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1,
             include_sample_rate=True)
         ret = self.availability.get_geoCSV_report(result).strip()
-        with open('ph5/test_data/metadata/avail_time.csv', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time.csv'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         result = self.availability.get_availability(
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_geoCSV_report(result).strip()
-        with open('ph5/test_data/metadata/avail_time_noSR.csv', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time_noSR.csv'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1729,8 +1775,9 @@ class TestPH5Availability(LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_sync_report(result).strip()
         i1 = ret.find('\n')
-        with open('ph5/test_data/metadata/extent_full.sync', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.sync'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1740,8 +1787,10 @@ class TestPH5Availability(LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_sync_report(result).strip()
         i1 = ret.find('\n')
-        with open('ph5/test_data/metadata/avail_time.sync', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time.sync'),
+                  'r'
+                  ) as content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1750,8 +1799,9 @@ class TestPH5Availability(LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_sync_report(result).strip()
         i1 = ret.find('\n')
-        with open('ph5/test_data/metadata/avail_time_noSR.sync', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time_noSR.sync'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1764,8 +1814,9 @@ class TestPH5Availability(LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_json_report(result).strip()
         i1 = ret.find('"datasources"')
-        with open('ph5/test_data/metadata/extent_full.json', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.json'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1775,8 +1826,9 @@ class TestPH5Availability(LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_json_report(result).strip()
         i1 = ret.find('"datasources"')
-        with open('ph5/test_data/metadata/avail_time.json', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time.json'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1785,8 +1837,9 @@ class TestPH5Availability(LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_json_report(result).strip()
         i1 = ret.find('"datasources"')
-        with open('ph5/test_data/metadata/avail_time_noSR.json', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/avail_time_noSR.json'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1805,29 +1858,33 @@ class TestPH5Availability(LogTestCase):
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_report(result, format='t').strip()
-        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.txt'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         ret = self.availability.get_report(result, format='g').strip()
-        with open('ph5/test_data/metadata/extent_full.csv', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.csv'),
+                  'r') as content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         ret = self.availability.get_report(result, format='s').strip()
         i1 = ret.find('\n')
-        with open('ph5/test_data/metadata/extent_full.sync', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.sync'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
 
         ret = self.availability.get_report(result, format='j').strip()
         i1 = ret.find('"datasources"')
-        with open('ph5/test_data/metadata/extent_full.json', 'r') as \
-                content_file:
+        with open(os.path.join(self.home,
+                               'ph5/test_data/metadata/extent_full.json'),
+                  'r') as content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1837,13 +1894,6 @@ class TestPH5Availability(LogTestCase):
             self.assertEqual(ret, result)
             self.assertEqual(log.records[0].msg,
                              "The entered format k is not supported.")
-
-    def tearDown(self):
-        """
-        teardown for tests
-        """
-        self.ph5_object.close()
-        super(TestPH5Availability, self).tearDown()
 
 
 if __name__ == "__main__":

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -1733,6 +1733,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         with open('test', 'r') as content_file:
             content = content_file.read().strip()
         self.assertEqual(content, "this is a text line")
+        os.remove('test')
 
     def test_get_geoCSV_report(self):
         """

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -5,6 +5,7 @@ unit tests for ph5availability
 import unittest
 import sys
 import os
+import logging
 
 from mock import patch
 from testfixtures import OutputCapture, LogCapture
@@ -1255,17 +1256,26 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                     '-a', '4', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
-                ph5availability.main()
-                out.compare('')
-
+                with LogCapture() as log:
+                    log.setLevel(logging.ERROR)
+                    ph5availability.main()
+                    out.compare('')
+                    self.assertEqual(log.records[0].msg,
+                                     "get_availability_percentage requires "
+                                     "providing exact station/channel.")
         # test get_availability_percentage with channel, no station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
                     self.ph5test_path,
                     '-a', '4', '-c', 'DP2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
-                ph5availability.main()
-                out.compare('')
+                with LogCapture() as log:
+                    log.setLevel(logging.ERROR)
+                    ph5availability.main()
+                    out.compare('')
+                    self.assertEqual(log.records[0].msg,
+                                     "get_availability_percentage requires "
+                                     "providing exact station/channel.")
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
@@ -1274,8 +1284,13 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                     '--station', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
-                ph5availability.main()
-                out.compare('')
+                with LogCapture() as log:
+                    log.setLevel(logging.ERROR)
+                    ph5availability.main()
+                    out.compare('')
+                    self.assertEqual(log.records[0].msg,
+                                     "get_availability_percentage requires "
+                                     "providing exact station/channel.")
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -65,9 +65,6 @@ def checkFieldsMatch(fieldNames, fieldsList, dictList):
 
 class TestPH5Availability(LogTestCase, TempDirTestCase):
     def setUp(self):
-        """
-        setup for tests
-        """
         super(TestPH5Availability, self).setUp()
         self.ph5test_path = os.path.join(self.home, 'ph5/test_data/ph5')
         self.ph5_object = ph5api.PH5(
@@ -77,17 +74,10 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
             self.ph5_object)
 
     def tearDown(self):
-        """
-        teardown for tests
-        """
         self.ph5_object.close()
         super(TestPH5Availability, self).tearDown()
 
     def test_get_slc(self):
-        """
-        test get_slc method
-        """
-
         # should return ALL available
         # station location and channels
         ret = self.availability.get_slc()
@@ -304,9 +294,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual(0, len(ret))
 
     def test_get_availability_extent(self):
-        """
-        test get_availability_extent method
-        """
         # expected to return all extent information
         ret = self.availability.get_availability_extent()
         # There are 10 channels all with data
@@ -483,9 +470,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
             '*', '*', '*', None, 1502294460.38)
 
     def test_get_availability(self):
-        """
-        test get_availability method
-        """
         # expected to return all availability information
         ret = self.availability.get_availability()
         # There are 10 channels all with data
@@ -597,10 +581,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                          1502294400.38, 1502294460.38) in ret)
 
     def test_get_availability_percentage(self):
-        """
-        test get_availability_percentage method
-        """
-
         # should return 100% and 0 gaps
         ret = self.availability.get_availability_percentage(
             '500',
@@ -679,9 +659,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual(0, ret[1])
 
     def test_has_data(self):
-        """
-        test has_data method
-        """
         # assumes all for everything
         # should return true
         self.assertTrue(
@@ -847,9 +824,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                 endtime=1741883104))
 
     def test_get_args(self):
-        """
-        test get_args
-        """
         with OutputCapture():
             with self.assertRaises(SystemExit):
                 ph5availability.get_args([])
@@ -891,9 +865,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertDictEqual(ret, expect)
 
     def test_analyze_args(self):
-        """
-        test analyze_args method
-        """
         A = self.availability
         # test wrong format channel
         args = ph5availability.get_args(
@@ -1012,9 +983,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual(A.OFILE.closed, False)
 
     def test_main(self):
-        """
-        test main function
-        """
         # wrong path entered
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
                     'some/bad/path', '-a', '0']
@@ -1421,9 +1389,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertMultiLineEqual(output[i1:], content[i2:])
 
     def test_convert_time(self):
-        """
-        test convert_time method
-        """
         # convert list with epoch times at 3, 4
         ret = self.availability.convert_time(
             ['500', '', 'DP2', 1502294400.38, 1502294460.38])
@@ -1450,9 +1415,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
             ('500', '', 'DP2', 1502294400.38, 1502294460.38))
 
     def test_get_channel(self):
-        """
-        test get_channel method
-        """
         # get channel from station that lacks of info for channel
         ret = self.availability.get_channel({})
         self.assertEqual('DPX', ret)
@@ -1464,9 +1426,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual('LOG', ret)
 
     def test_get_slc_info(self):
-        """
-        test get_slc_info method
-        """
         arrayorder, arraybyid = self.availability.get_array_order_id(
             'Array_t_001')
         st = arraybyid['500'][1][0]
@@ -1502,17 +1461,11 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
             self.availability.get_slc_info, st, '500', '*', '*')
 
     def test_get_start(self):
-        """
-        test get_start method
-        """
         ret = self.availability.get_start(
             {'time/epoch_l': 1502294400, 'time/micro_seconds_i': 380000})
         self.assertEqual(1502294400.38, ret)
 
     def test_get_end(self):
-        """
-        test get_end method
-        """
         # samplerate != 0
         ret = self.availability.get_end(
             {'sample_count_i': 15000}, 1502294400.38, 500)
@@ -1524,9 +1477,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual(1502294400.38, ret)
 
     def test_get_sample_rate(self):
-        """
-        test get_sample_rate method
-        """
         # sample_rate_i != 0
         ret = self.availability.get_sample_rate(
             {'sample_rate_i': 100, 'sample_rate_multiplier_i': 1})
@@ -1538,9 +1488,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual(0, ret)
 
     def test_get_time_das_t(self):
-        """
-        test get_time_das_t method
-        """
         # start=None, end=None; no component, sample_rate
         ret = self.availability.get_time_das_t(
             '3X500', None, None)
@@ -1675,9 +1622,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual((46500, 7000.0, 4), ret)
 
     def test_get_array_order_id(self):
-        """
-        test get_array_order_id method
-        """
         ret = self.availability.get_array_order_id('Array_t_009')
         self.assertEqual(['9001'], ret[0])
         self.assertTrue(1, len(ret[1]))
@@ -1690,9 +1634,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
             'Array_t_010')
 
     def test_get_text_report(self):
-        """
-        test get_text_report method
-        """
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_text_report(result).strip()
@@ -1737,9 +1678,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertEqual(content, "this is a text line")
 
     def test_get_geoCSV_report(self):
-        """
-        test get_geoCSV_report method
-        """
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_geoCSV_report(result).strip()
@@ -1769,9 +1707,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertMultiLineEqual(ret, content)
 
     def test_get_sync_report(self):
-        """
-        test get_sync_report method
-        """
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_sync_report(result).strip()
@@ -1808,9 +1743,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.assertMultiLineEqual(ret[i1:], content[i2:])
 
     def test_get_json_report(self):
-        """
-        test get_json_report method
-        """
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_json_report(result).strip()
@@ -1853,9 +1785,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
             result)
 
     def test_get_report(self):
-        """
-        test get_report method
-        """
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_report(result, format='t').strip()

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -9,7 +9,7 @@ import sys
 import os
 from mock import patch
 from testfixtures import OutputCapture, LogCapture
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase
+from ph5.core.tests.test_base import LogTestCase
 
 
 def checkTupleAlmostEqualIn(tup, tupList, place):
@@ -61,25 +61,17 @@ def checkFieldsMatch(fieldNames, fieldsList, dictList):
     return True
 
 
-class TestPH5Availability(TempDirTestCase, LogTestCase):
+class TestPH5Availability(LogTestCase):
     def setUp(self):
         """
         setup for tests
         """
         super(TestPH5Availability, self).setUp()
-
         self.ph5_object = ph5api.PH5(
-            path=os.path.join(self.home, 'ph5/test_data/ph5'),
+            path='ph5/test_data/ph5',
             nickname='master.ph5')
         self.availability = ph5availability.PH5Availability(
             self.ph5_object)
-
-    def tearDown(self):
-        """
-        teardown for tests
-        """
-        self.ph5_object.close()
-        super(TestPH5Availability, self).tearDown()
 
     def test_get_slc(self):
         """
@@ -1022,8 +1014,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test has_data station with data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0', '--station',
+                    'ph5/test_data/ph5', '-a', '0', '--station',
                     '500', '--channel', 'DP1']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1034,8 +1025,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # expect to return True 3 times, once for each channel
         # master_PH5_file without extension
         testargs = ['ph5availability', '-n', 'master', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0', '--station', '500', '--channel', '*']
+                    'ph5/test_data/ph5', '-a', '0', '--station',
+                    '500', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1043,8 +1034,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test has_data station with no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0', '--station',
+                    'ph5/test_data/ph5', '-a', '0', '--station',
                     '9576', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1053,8 +1043,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test has_data station list data, no data,
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0', '--station', '9001,91234', '--channel', '*']
+                    'ph5/test_data/ph5', '-a', '0', '--station',
+                    '9001,91234', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1062,8 +1052,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test has_data with start time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0', '-s',
+                    'ph5/test_data/ph5', '-a', '0', '-s',
                     '2017-08-09T16:00:00.380000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1072,8 +1061,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test has_data with end time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0', '-e',
+                    'ph5/test_data/ph5', '-a', '0', '-e',
                     '2019-02-22T15:43:09.000000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1082,8 +1070,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test has_data with time range having data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0',
+                    'ph5/test_data/ph5', '-a', '0',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1093,8 +1080,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test has_data with time range having no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0',
+                    'ph5/test_data/ph5', '-a', '0',
                     '-s', '2017-08-09T16:01:01.0',
                     '-e', '2018-12-17T22:20:30.0', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1103,8 +1089,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
                 out.compare('False')
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '0', '-A', '2']
+                    'ph5/test_data/ph5', '-a', '0', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1113,8 +1098,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # ------------------------------------------------------------ #
         # test get_slc with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '1', '--station', '0407']
+                    'ph5/test_data/ph5', '-a', '1', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1124,8 +1108,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_slc with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '1', '-c', 'LOG']
+                    'ph5/test_data/ph5', '-a', '1', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1133,8 +1116,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_slc with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '1',
+                    'ph5/test_data/ph5', '-a', '1',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000']
         with patch.object(sys, 'argv', testargs):
@@ -1144,8 +1126,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_slc with array
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '1', '-A', '2']
+                    'ph5/test_data/ph5', '-a', '1', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1154,8 +1135,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # ------------------------------------------------------------ #
         # test get_availability with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '2', '--station', '0407']
+                    'ph5/test_data/ph5', '-a', '2', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1171,8 +1151,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '2', '-c', 'LOG']
+                    'ph5/test_data/ph5', '-a', '2', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1184,8 +1163,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '2',
+                    'ph5/test_data/ph5', '-a', '2',
                     '-s', '2018-12-17T23:10:05.0',
                     '-e', '2019-02-22T15:39:03.1']
         with patch.object(sys, 'argv', testargs):
@@ -1200,8 +1178,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
                     " 2019-02-22T15:39:03.099999Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '2', '-A', '4']
+                    'ph5/test_data/ph5', '-a', '2', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1214,8 +1191,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_extent with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '--station', '9001']
+                    'ph5/test_data/ph5', '-a', '3', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1229,8 +1205,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # if wrong format is stated, still print out tuple result with
         # a warning
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '-c', 'DP2', '-F', 'k']
+                    'ph5/test_data/ph5', '-a', '3', '-c', 'DP2', '-F', 'k']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1239,8 +1214,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability_extent with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '-S',
+                    'ph5/test_data/ph5', '-a', '3', '-S',
                     '-s', '2019-02-22T15:39:04.1',
                     '-e', '2019-02-22T15:39:07.1']
         with patch.object(sys, 'argv', testargs):
@@ -1254,8 +1228,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability_extent with wildcard station, location, channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3',
+                    'ph5/test_data/ph5', '-a', '3',
                     '--station', '?001', '-l', '*', '-c', 'DP?']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1267,8 +1240,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
                     " 2019-02-22T15:43:09.000000Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '-A', '4']
+                    'ph5/test_data/ph5', '-a', '3', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1281,8 +1253,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_percentage with station, no channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '4', '--station', '9001']
+                    'ph5/test_data/ph5', '-a', '4', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1290,8 +1261,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability_percentage with channel, no station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '4', '-c', 'DP2']
+                    'ph5/test_data/ph5', '-a', '4', '-c', 'DP2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
@@ -1299,8 +1269,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '4', '-c', 'DP2',
+                    'ph5/test_data/ph5', '-a', '4', '-c', 'DP2',
                     '--station', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1309,8 +1278,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '4', '-c', 'DP1',
+                    'ph5/test_data/ph5', '-a', '4', '-c', 'DP1',
                     '--station', '500']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1319,8 +1287,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test get_availability_percentage with station, channel, time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '4', '--station', '9001',
+                    'ph5/test_data/ph5', '-a', '4', '--station', '9001',
                     '-s', '2019-02-22T15:39:03.0', '-c', 'DPZ',
                     '-e', '2019-02-22T15:40:03.0']
         with patch.object(sys, 'argv', testargs):
@@ -1330,8 +1297,7 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # test get_availability_percentage with station, channel, time, and
         # array not match with other parameters
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '4', '-A', '3',
+                    'ph5/test_data/ph5', '-a', '4', '-A', '3',
                     '--station', '0407', '-c', 'HHN']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1343,12 +1309,10 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # should return 10 channels
         # should match slc_full.txt from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3',
+                    'ph5/test_data/ph5', '-a', '3',
                     '-F', 't', '-S']
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.txt'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
+                content_file:
             content = content_file.read().strip()
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1359,11 +1323,10 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         # should return 10 channels
         # should match slc_full_geocsv.csv from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '-F', 'g', '-S']
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.csv'),
-                  'r') as content_file:
+                    'ph5/test_data/ph5', '-a', '3',
+                    '-F', 'g', '-S']
+        with open('ph5/test_data/metadata/extent_full.csv', 'r') as \
+                content_file:
             content = content_file.read().strip()
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1372,11 +1335,10 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test extent and text format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '-F', 't', '-S']
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.txt'),
-                  'r') as content_file:
+                    'ph5/test_data/ph5', '-a', '3',
+                    '-F', 't', '-S']
+        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
+                content_file:
             content = content_file.read().strip()
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1386,17 +1348,16 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         self.maxDiff = None
         # test extent and sync format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '-F', 's', '-S']
+                    'ph5/test_data/ph5', '-a', '3',
+                    '-F', 's', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
                 output = out.captured.strip()
 
         i1 = output.find('\n')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.sync'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.sync', 'r') as \
+                content_file:
             content = content_file.read().strip()
 
         i2 = content.find('\n')
@@ -1404,16 +1365,15 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
 
         # test extent and json format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
-                    '-a', '3', '-F', 'j', '-S']
+                    'ph5/test_data/ph5', '-a', '3',
+                    '-F', 'j', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
                 ph5availability.main()
                 output = out.captured.strip()
         i1 = output.find('"datasources"')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.json'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.json', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(output[i1:], content[i2:])
@@ -1694,9 +1654,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_text_report(result).strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.txt'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1704,18 +1663,16 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1,
             include_sample_rate=True)
         ret = self.availability.get_text_report(result).strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time.txt'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/avail_time.txt', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         result = self.availability.get_availability(
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_text_report(result).strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time_noSR.txt'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/avail_time_noSR.txt', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1742,9 +1699,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_geoCSV_report(result).strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.csv'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.csv', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1752,18 +1708,16 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1,
             include_sample_rate=True)
         ret = self.availability.get_geoCSV_report(result).strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time.csv'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/avail_time.csv', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         result = self.availability.get_availability(
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_geoCSV_report(result).strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time_noSR.csv'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/avail_time_noSR.csv', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
@@ -1775,9 +1729,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_sync_report(result).strip()
         i1 = ret.find('\n')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.sync'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.sync', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1787,10 +1740,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_sync_report(result).strip()
         i1 = ret.find('\n')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time.sync'),
-                  'r'
-                  ) as content_file:
+        with open('ph5/test_data/metadata/avail_time.sync', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1799,9 +1750,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_sync_report(result).strip()
         i1 = ret.find('\n')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time_noSR.sync'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/avail_time_noSR.sync', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1814,9 +1764,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_json_report(result).strip()
         i1 = ret.find('"datasources"')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.json'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.json', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1826,9 +1775,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             include_sample_rate=True)
         ret = self.availability.get_json_report(result).strip()
         i1 = ret.find('"datasources"')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time.json'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/avail_time.json', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1837,9 +1785,8 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             starttime=1545088205.0, endtime=1550849943.1)
         ret = self.availability.get_json_report(result).strip()
         i1 = ret.find('"datasources"')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/avail_time_noSR.json'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/avail_time_noSR.json', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1858,33 +1805,29 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
         result = self.availability.get_availability_extent(
             include_sample_rate=True)
         ret = self.availability.get_report(result, format='t').strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.txt'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.txt', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         ret = self.availability.get_report(result, format='g').strip()
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.csv'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.csv', 'r') as \
+                content_file:
             content = content_file.read().strip()
         self.assertMultiLineEqual(ret, content)
 
         ret = self.availability.get_report(result, format='s').strip()
         i1 = ret.find('\n')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.sync'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.sync', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('\n')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
 
         ret = self.availability.get_report(result, format='j').strip()
         i1 = ret.find('"datasources"')
-        with open(os.path.join(self.home,
-                               'ph5/test_data/metadata/extent_full.json'),
-                  'r') as content_file:
+        with open('ph5/test_data/metadata/extent_full.json', 'r') as \
+                content_file:
             content = content_file.read().strip()
         i2 = content.find('"datasources"')
         self.assertMultiLineEqual(ret[i1:], content[i2:])
@@ -1894,6 +1837,13 @@ class TestPH5Availability(TempDirTestCase, LogTestCase):
             self.assertEqual(ret, result)
             self.assertEqual(log.records[0].msg,
                              "The entered format k is not supported.")
+
+    def tearDown(self):
+        """
+        teardown for tests
+        """
+        self.ph5_object.close()
+        super(TestPH5Availability, self).tearDown()
 
 
 if __name__ == "__main__":

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -67,9 +67,9 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         setup for tests
         """
         super(TestPH5Availability, self).setUp()
-
+        self.ph5test_path = os.path.join(self.home, 'ph5/test_data/ph5')
         self.ph5_object = ph5api.PH5(
-            path=os.path.join(self.home, 'ph5/test_data/ph5'),
+            path=self.ph5test_path,
             nickname='master.ph5')
         self.availability = ph5availability.PH5Availability(
             self.ph5_object)
@@ -855,31 +855,31 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                 ph5availability.get_args(['-n', 'master.ph5'])
             with self.assertRaises(SystemExit):
                 ph5availability.get_args(
-                    ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5'])
+                    ['-n', 'master.ph5', '-p', self.ph5test_path])
             # test false args
             with self.assertRaises(SystemExit):
                 ph5availability.get_args(
-                    ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5',
+                    ['-n', 'master.ph5', '-p', self.ph5test_path,
                      '-a', '0', '-T'])
         # test default args
         ret = vars(ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0']))
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0']))
         expect = {
             'array_t_': None, 'format': None, 'start_time': None,
             'output_file': None, 'avail': 0, 'end_time': None,
-            'sta_id_list': [], 'ph5path': 'ph5/test_data/ph5',
+            'sta_id_list': [], 'ph5path': self.ph5test_path,
             'samplerate': False, 'nickname': 'master.ph5', 'sta_list': [],
             'channel': [], 'location': None}
         self.assertDictEqual(ret, expect)
         # test correct args received
         ret = vars(ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '-s', '2017-08-09T16:00:00.380000',
              '-e', '2017-08-09T16:01:00.380000', '--station', '500,0407',
              '--station_id', '500,0407', '-l', '00', '-c', 'DP1', '-S',
              '-A', '1', '-F', 't', '-o', 'extent.txt']))
         expect = {
-            'array_t_': 1, 'format': 't', 'ph5path': 'ph5/test_data/ph5',
+            'array_t_': 1, 'format': 't', 'ph5path': self.ph5test_path,
             'output_file': 'extent.txt', 'avail': 0,
             'start_time': '2017-08-09T16:00:00.380000',
             'end_time': '2017-08-09T16:01:00.380000',
@@ -895,41 +895,41 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         A = self.availability
         # test wrong format channel
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '-c', '1 2 3'])
         self.assertRaises(
             ph5availability.PH5AvailabilityError, A.analyze_args, args)
 
         # test wrong format location: len > 2
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '-l', 'Oaa'])
         self.assertRaises(
             ph5availability.PH5AvailabilityError, A.analyze_args, args)
 
         # test wrong format location: invalid character
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '-l', 'O^'])
         self.assertRaises(
             ph5availability.PH5AvailabilityError, A.analyze_args, args)
 
         # test wrong format station
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '--station', 'o-g'])
         self.assertRaises(
             ph5availability.PH5AvailabilityError, A.analyze_args, args)
 
         # test wrong avail:5
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '5'])
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '5'])
         self.assertRaises(
             ph5availability.PH5AvailabilityError, A.analyze_args, args)
 
         # given -o but avail not 2 or 3
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5',
+            ['-n', 'master.ph5', '-p', self.ph5test_path,
              '-a', '0', '-o', 'test'])
         ret = A.analyze_args(args)
         self.assertEqual(ret, True)
@@ -937,7 +937,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # given -o, avail=2 but no format given
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5',
+            ['-n', 'master.ph5', '-p', self.ph5test_path,
              '-a', '2', '-o', 'test'])
         ret = A.analyze_args(args)
         self.assertEqual(ret, True)
@@ -945,7 +945,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test default args
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0'])
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0'])
         ret = A.analyze_args(args)
         self.assertEqual(ret, True)
         self.assertEqual(A.stations, ['*'])
@@ -960,7 +960,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test wildcard station, location, channel
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '--station', '*', '-l', '*', '-c', '*'])
         ret = A.analyze_args(args)
         self.assertEqual(ret, True)
@@ -970,7 +970,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test wildcard station, location, channel
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '--station_id', '?001', '-l', '??', '-c', 'DP?'])
         ret = A.analyze_args(args)
         self.assertEqual(ret, True)
@@ -981,7 +981,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # test args are assigned correctly,
         # a=0, check if SR_included=False, OFILE=None
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '0',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '0',
              '-s', '2017-08-09T16:00:00.380000',
              '-e', '2017-08-09T16:01:00.380000', '--station', '500,0407',
              '-l', '00', '-c', 'DP1', '-S',
@@ -1001,7 +1001,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # same args, with avail=2, check if SR_included=True
         args = ph5availability.get_args(
-            ['-n', 'master.ph5', '-p', 'ph5/test_data/ph5', '-a', '2',
+            ['-n', 'master.ph5', '-p', self.ph5test_path, '-a', '2',
              '-S', '-F', 't', '-o', 'extent.txt'])
         ret = A.analyze_args(args)
         self.assertEqual(A.SR_included, True)
@@ -1022,7 +1022,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data station with data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0', '--station',
                     '500', '--channel', 'DP1']
         with patch.object(sys, 'argv', testargs):
@@ -1034,7 +1034,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # expect to return True 3 times, once for each channel
         # master_PH5_file without extension
         testargs = ['ph5availability', '-n', 'master', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0', '--station', '500', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1043,7 +1043,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data station with no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0', '--station',
                     '9576', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1053,7 +1053,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data station list data, no data,
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0', '--station', '9001,91234', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1062,7 +1062,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with start time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0', '-s',
                     '2017-08-09T16:00:00.380000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1072,7 +1072,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with end time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0', '-e',
                     '2019-02-22T15:43:09.000000', '--channel', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1082,7 +1082,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with time range having data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000', '--channel', '*']
@@ -1093,7 +1093,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test has_data with time range having no data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0',
                     '-s', '2017-08-09T16:01:01.0',
                     '-e', '2018-12-17T22:20:30.0', '--channel', '*']
@@ -1103,7 +1103,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                 out.compare('False')
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '0', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1113,7 +1113,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_slc with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '1', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1124,7 +1124,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_slc with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '1', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1133,7 +1133,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_slc with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '1',
                     '-s', '2019-02-22T15:39:03.000000',
                     '-e', '2019-02-22T15:43:09.000000']
@@ -1144,7 +1144,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_slc with array
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '1', '-A', '2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1154,7 +1154,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_availability with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '2', '--station', '0407']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1171,7 +1171,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability with channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '2', '-c', 'LOG']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1184,7 +1184,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '2',
                     '-s', '2018-12-17T23:10:05.0',
                     '-e', '2019-02-22T15:39:03.1']
@@ -1200,7 +1200,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                     " 2019-02-22T15:39:03.099999Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '2', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1214,7 +1214,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_extent with station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1229,7 +1229,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # if wrong format is stated, still print out tuple result with
         # a warning
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '-c', 'DP2', '-F', 'k']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1239,7 +1239,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_extent with time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '-S',
                     '-s', '2019-02-22T15:39:04.1',
                     '-e', '2019-02-22T15:39:07.1']
@@ -1254,7 +1254,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_extent with wildcard station, location, channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3',
                     '--station', '?001', '-l', '*', '-c', 'DP?']
         with patch.object(sys, 'argv', testargs):
@@ -1267,7 +1267,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
                     " 2019-02-22T15:43:09.000000Z")
 
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '-A', '4']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1281,7 +1281,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # ------------------------------------------------------------ #
         # test get_availability_percentage with station, no channel
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '4', '--station', '9001']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1290,7 +1290,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_percentage with channel, no station
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '4', '-c', 'DP2']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1299,7 +1299,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '4', '-c', 'DP2',
                     '--station', '*']
         with patch.object(sys, 'argv', testargs):
@@ -1309,7 +1309,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_percentage with channel, station=*
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '4', '-c', 'DP1',
                     '--station', '500']
         with patch.object(sys, 'argv', testargs):
@@ -1319,7 +1319,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test get_availability_percentage with station, channel, time
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '4', '--station', '9001',
                     '-s', '2019-02-22T15:39:03.0', '-c', 'DPZ',
                     '-e', '2019-02-22T15:40:03.0']
@@ -1330,7 +1330,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # test get_availability_percentage with station, channel, time, and
         # array not match with other parameters
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '4', '-A', '3',
                     '--station', '0407', '-c', 'HHN']
         with patch.object(sys, 'argv', testargs):
@@ -1343,7 +1343,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # should return 10 channels
         # should match slc_full.txt from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3',
                     '-F', 't', '-S']
         with open(os.path.join(self.home,
@@ -1359,7 +1359,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         # should return 10 channels
         # should match slc_full_geocsv.csv from test data
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '-F', 'g', '-S']
         with open(os.path.join(self.home,
                                'ph5/test_data/metadata/extent_full.csv'),
@@ -1372,7 +1372,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test extent and text format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '-F', 't', '-S']
         with open(os.path.join(self.home,
                                'ph5/test_data/metadata/extent_full.txt'),
@@ -1386,7 +1386,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         self.maxDiff = None
         # test extent and sync format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '-F', 's', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:
@@ -1404,7 +1404,7 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
         # test extent and json format
         testargs = ['ph5availability', '-n', 'master.ph5', '-p',
-                    os.path.join(self.home, 'ph5/test_data/ph5'),
+                    self.ph5test_path,
                     '-a', '3', '-F', 'j', '-S']
         with patch.object(sys, 'argv', testargs):
             with OutputCapture() as out:

--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -3,12 +3,14 @@ unit tests for ph5availability
 """
 
 import unittest
-from ph5.clients import ph5availability
-from ph5.core import ph5api
 import sys
 import os
+
 from mock import patch
 from testfixtures import OutputCapture, LogCapture
+
+from ph5.clients import ph5availability
+from ph5.core import ph5api
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase
 
 
@@ -1733,7 +1735,6 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
         with open('test', 'r') as content_file:
             content = content_file.read().strip()
         self.assertEqual(content, "this is a text line")
-        os.remove('test')
 
     def test_get_geoCSV_report(self):
         """

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -5,7 +5,7 @@ import unittest
 import logging
 from StringIO import StringIO
 
-from ph5 import logger, ch
+from ph5 import logger
 from ph5.core import experiment
 
 
@@ -17,32 +17,29 @@ def initialize_ex(nickname, path, editmode=False):
 
 
 class LogTestCase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         # enable propagating to higher loggers
         logger.propagate = 1
-        # disable writing log to console
-        logger.removeHandler(ch)
-        # add StringIO handler to prevent message "No handlers could be found"
+        self.handlers = logger.handlers
+        logger.handlers = []
+        # add StringIO handler to catch log in need
         log = StringIO()
-        cls.newch = logging.StreamHandler(log)
-        logger.addHandler(cls.newch)
+        new_handler = logging.StreamHandler(log)
+        logger.addHandler(new_handler)
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         # disable propagating to higher loggers
         logger.propagate = 0
-        # revert logger handler
-        logger.removeHandler(cls.newch)
-        logger.addHandler(ch)
+        logger.handlers = self.handlers
 
 
-class TempDirTestCase(unittest.TestCase):
+class TempDirTestCase(LogTestCase):
 
     def setUp(self):
         """
         create tmpdir
         """
+        super(TempDirTestCase, self).setUp()
         self.home = os.getcwd()
         self.tmpdir = tempfile.mkdtemp(dir=self.home + "/ph5/test_data/")
         os.chdir(self.tmpdir)
@@ -60,3 +57,4 @@ class TempDirTestCase(unittest.TestCase):
             print(errmsg)
 
         os.chdir(self.home)
+        super(TempDirTestCase, self).tearDown()

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -72,4 +72,5 @@ class TempDirTestCase(unittest.TestCase):
             errmsg = "%s has FAILED. Inspect files created in %s." \
                 % (self._testMethodName, self.tmpdir)
             print(errmsg)
+
         os.chdir(self.home)

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import tempfile
 import unittest
 import logging
 from StringIO import StringIO
@@ -13,10 +14,6 @@ def initialize_ex(nickname, path, editmode=False):
     ex.ph5open(editmode)
     ex.initgroup()
     return ex
-
-
-def del_files_in_dir(directory):
-    map(os.unlink, (os.path.join(directory, f) for f in os.listdir(directory)))
 
 
 class LogTestCase(unittest.TestCase):
@@ -47,8 +44,7 @@ class TempDirTestCase(unittest.TestCase):
         create tmpdir
         """
         self.home = os.getcwd()
-        os.mkdir("ph5/test_data/tmp")
-        self.tmpdir = self.home + "/ph5/test_data/tmp"
+        self.tmpdir = tempfile.mkdtemp(dir=self.home + '/ph5/test_data/')
         os.chdir(self.tmpdir)
 
     def tearDown(self):

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -54,13 +54,6 @@ class LogTestCase(unittest.TestCase):
                         file_logger_handlers.append((logging.getLogger(k), h))
         return file_logger_handlers
 
-    def remove_all_file_handlers(self):
-        for k, v in logging.Logger.manager.loggerDict.items():
-            if not isinstance(v, logging.PlaceHolder):
-                for h in v.handlers:
-                    if isinstance(h, logging.FileHandler):
-                        logging.getLogger(k).removeHandler(h)
-
 
 class TempDirTestCase(unittest.TestCase):
     total_error_failure = 0

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import tempfile
 import unittest
 import logging
 from StringIO import StringIO
@@ -13,10 +14,6 @@ def initialize_ex(nickname, path, editmode=False):
     ex.ph5open(editmode)
     ex.initgroup()
     return ex
-
-
-def del_files_in_dir(directory):
-    map(os.unlink, (os.path.join(directory, f) for f in os.listdir(directory)))
 
 
 class LogTestCase(unittest.TestCase):
@@ -42,16 +39,16 @@ class LogTestCase(unittest.TestCase):
 
 class TempDirTestCase(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self, changedir=True):
         """
         create tmpdir
         """
         self.home = os.getcwd()
-        os.mkdir("ph5/test_data/tmp")
-        self.tmpdir = self.home + "/ph5/test_data/tmp"
-        os.chdir(self.tmpdir)
+        self.tmpdir = tempfile.mkdtemp() + "/"
+        if changedir:
+            os.chdir(self.tmpdir)
 
-    def tearDown(self):
+    def tearDown(self, changedir=True):
         if self._resultForDoCleanups.wasSuccessful():
             try:
                 shutil.rmtree(self.tmpdir)
@@ -63,4 +60,5 @@ class TempDirTestCase(unittest.TestCase):
                 % (self._testMethodName, self.tmpdir)
             print(errmsg)
 
-        os.chdir(self.home)
+        if changedir:
+            os.chdir(self.home)

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -1,10 +1,11 @@
-from ph5 import logger, ch
-from StringIO import StringIO
-import logging
-import unittest
 import os
 import shutil
 import tempfile
+import unittest
+import logging
+from StringIO import StringIO
+
+from ph5 import logger, ch
 from ph5.core import experiment
 
 

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import tempfile
 import unittest
 import logging
 from StringIO import StringIO
@@ -14,6 +13,10 @@ def initialize_ex(nickname, path, editmode=False):
     ex.ph5open(editmode)
     ex.initgroup()
     return ex
+
+
+def del_files_in_dir(directory):
+    map(os.unlink, (os.path.join(directory, f) for f in os.listdir(directory)))
 
 
 class LogTestCase(unittest.TestCase):
@@ -39,16 +42,16 @@ class LogTestCase(unittest.TestCase):
 
 class TempDirTestCase(unittest.TestCase):
 
-    def setUp(self, changedir=True):
+    def setUp(self):
         """
         create tmpdir
         """
         self.home = os.getcwd()
-        self.tmpdir = tempfile.mkdtemp() + "/"
-        if changedir:
-            os.chdir(self.tmpdir)
+        os.mkdir("ph5/test_data/tmp")
+        self.tmpdir = self.home + "/ph5/test_data/tmp"
+        os.chdir(self.tmpdir)
 
-    def tearDown(self, changedir=True):
+    def tearDown(self):
         if self._resultForDoCleanups.wasSuccessful():
             try:
                 shutil.rmtree(self.tmpdir)
@@ -60,5 +63,4 @@ class TempDirTestCase(unittest.TestCase):
                 % (self._testMethodName, self.tmpdir)
             print(errmsg)
 
-        if changedir:
-            os.chdir(self.home)
+        os.chdir(self.home)

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -46,6 +46,7 @@ class LogTestCase(unittest.TestCase):
 
 
 class TempDirTestCase(unittest.TestCase):
+    total_error_failure = 0
 
     def setUp(self):
         """
@@ -62,7 +63,10 @@ class TempDirTestCase(unittest.TestCase):
 
     def tearDown(self):
         super(TempDirTestCase, self).tearDown()
-        if self._resultForDoCleanups.wasSuccessful():
+        current_total_error_failure = len(self._resultForDoCleanups.errors) + \
+            len(self._resultForDoCleanups.failures)
+
+        if current_total_error_failure == TempDirTestCase.total_error_failure:
             try:
                 shutil.rmtree(self.tmpdir)
             except Exception as e:
@@ -72,5 +76,5 @@ class TempDirTestCase(unittest.TestCase):
             errmsg = "%s has FAILED. Inspect files created in %s." \
                 % (self._testMethodName, self.tmpdir)
             print(errmsg)
-
+            TempDirTestCase.total_error_failure = current_total_error_failure
         os.chdir(self.home)

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -6,8 +6,6 @@ import os
 import shutil
 import tempfile
 
-newch = None
-
 
 class LogTestCase(unittest.TestCase):
     @classmethod
@@ -18,15 +16,15 @@ class LogTestCase(unittest.TestCase):
         logger.removeHandler(ch)
         # add StringIO handler to prevent message "No handlers could be found"
         log = StringIO()
-        newch = logging.StreamHandler(log)
-        logger.addHandler(newch)
+        cls.newch = logging.StreamHandler(log)
+        logger.addHandler(cls.newch)
 
     @classmethod
     def tearDownClass(cls):
         # disable propagating to higher loggers
         logger.propagate = 0
         # revert logger handler
-        logger.removeHandler(newch)
+        logger.removeHandler(cls.newch)
         logger.addHandler(ch)
 
 

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -5,7 +5,7 @@ import unittest
 import logging
 from StringIO import StringIO
 
-from ph5 import logger
+from ph5 import logger, ch
 from ph5.core import experiment
 
 
@@ -21,28 +21,45 @@ class LogTestCase(unittest.TestCase):
     def setUpClass(cls):
         # enable propagating to higher loggers
         logger.propagate = 1
-        cls.handlers = [h for h in logger.handlers]
-        # switch handler that send log to console
-        # to StringIO handler to catch log's messages in test
+        # disable writing log to console
+        logger.removeHandler(ch)
+        # add StringIO handler to prevent message "No handlers could be found"
         log = StringIO()
-        new_handler = logging.StreamHandler(log)
-        logger.handlers = [new_handler]
+        cls.newch = logging.StreamHandler(log)
+        logger.addHandler(cls.newch)
 
     @classmethod
     def tearDownClass(cls):
         # disable propagating to higher loggers
         logger.propagate = 0
-        # put back the stream handler in ph5.__init__.logger
-        logger.handlers = cls.handlers
+        # revert logger handler
+        logger.removeHandler(cls.newch)
+        logger.addHandler(ch)
 
     def tearDown(self):
-        # clean up handlers in any ph5 files' loggers that have been used
-        # but exclude logger from ph5/__init__.py to catch log's messages in
-        # next test
-        for k, v in logging.Logger.manager.loggerDict.items():
-            if (not isinstance(v, logging.PlaceHolder)) and ('ph5.' in k):
-                v.handlers = []
+        file_loggers = self.find_all_file_loggers()
+        if file_loggers:
+            # remove all file handlers
+            for l, h in self.find_all_file_loggers():
+                l.removeHandler(h)
         super(LogTestCase, self).tearDown()
+
+    @staticmethod
+    def find_all_file_loggers():
+        file_logger_handlers = list()
+        for k, v in logging.Logger.manager.loggerDict.items():
+            if not isinstance(v, logging.PlaceHolder):
+                for h in v.handlers:
+                    if isinstance(h, logging.FileHandler):
+                        file_logger_handlers.append((logging.getLogger(k), h))
+        return file_logger_handlers
+
+    def remove_all_file_handlers(self):
+        for k, v in logging.Logger.manager.loggerDict.items():
+            if not isinstance(v, logging.PlaceHolder):
+                for h in v.handlers:
+                    if isinstance(h, logging.FileHandler):
+                        logging.getLogger(k).removeHandler(h)
 
 
 class TempDirTestCase(unittest.TestCase):
@@ -52,8 +69,6 @@ class TempDirTestCase(unittest.TestCase):
         """
         create tmpdir
         """
-        self.tmpdir = None
-        self.home = None
         self.home = os.getcwd()
         self.tmpdir = tempfile.mkdtemp(
             dir=os.path.join(self.home, "ph5/test_data/"))

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -39,15 +39,16 @@ class LogTestCase(unittest.TestCase):
 
 class TempDirTestCase(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self, changedir=True):
         """
         create tmpdir
         """
         self.home = os.getcwd()
         self.tmpdir = tempfile.mkdtemp() + "/"
-        os.chdir(self.tmpdir)
+        if changedir:
+            os.chdir(self.tmpdir)
 
-    def tearDown(self):
+    def tearDown(self, changedir=True):
         if self._resultForDoCleanups.wasSuccessful():
             try:
                 shutil.rmtree(self.tmpdir)
@@ -59,4 +60,5 @@ class TempDirTestCase(unittest.TestCase):
                 % (self._testMethodName, self.tmpdir)
             print(errmsg)
 
-        os.chdir(self.home)
+        if changedir:
+            os.chdir(self.home)

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -44,7 +44,7 @@ class TempDirTestCase(unittest.TestCase):
         create tmpdir
         """
         self.home = os.getcwd()
-        self.tmpdir = tempfile.mkdtemp() + "/"
+        self.tmpdir = tempfile.mkdtemp(dir=self.home + "/ph5/test_data/")
         os.chdir(self.tmpdir)
 
     def tearDown(self):

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -17,38 +17,50 @@ def initialize_ex(nickname, path, editmode=False):
 
 
 class LogTestCase(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # enable propagating to higher loggers
         logger.propagate = 1
-        self.handlers = [h for h in logger.handlers]
-        for handler in logger.handlers:
-            logger.removeHandler(handler)
-        # add StringIO handler to catch log in need
+        cls.handlers = [h for h in logger.handlers]
+        # switch handler that send log to console
+        # to StringIO handler to catch log's messages in test
         log = StringIO()
         new_handler = logging.StreamHandler(log)
-        logger.addHandler(new_handler)
+        logger.handlers = [new_handler]
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         # disable propagating to higher loggers
         logger.propagate = 0
-        for handler in logger.handlers:
-            logger.removeHandler(handler)
-        for handler in self.handlers:
-            logger.addHandler(handler)
+        # put back the stream handler in ph5.__init__.logger
+        logger.handlers = cls.handlers
+
+    def tearDown(self):
+        # clean up handlers in any ph5 files' loggers that have been used
+        # but exclude logger from ph5/__init__.py to catch log's messages in
+        # next test
+        for k, v in logging.Logger.manager.loggerDict.items():
+            if (not isinstance(v, logging.PlaceHolder)) and ('ph5.' in k):
+                v.handlers = []
+        super(LogTestCase, self).tearDown()
 
 
-class TempDirTestCase(LogTestCase):
+class TempDirTestCase(unittest.TestCase):
 
     def setUp(self):
         """
         create tmpdir
         """
-        super(TempDirTestCase, self).setUp()
+        self.tmpdir = None
+        self.home = None
         self.home = os.getcwd()
         self.tmpdir = tempfile.mkdtemp(dir=self.home + "/ph5/test_data/")
         os.chdir(self.tmpdir)
+        self.addCleanup(os.chdir, self.home)
+        super(TempDirTestCase, self).setUp()
 
     def tearDown(self):
+        super(TempDirTestCase, self).tearDown()
         if self._resultForDoCleanups.wasSuccessful():
             try:
                 shutil.rmtree(self.tmpdir)
@@ -59,6 +71,4 @@ class TempDirTestCase(LogTestCase):
             errmsg = "%s has FAILED. Inspect files created in %s." \
                 % (self._testMethodName, self.tmpdir)
             print(errmsg)
-
         os.chdir(self.home)
-        super(TempDirTestCase, self).tearDown()

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -20,8 +20,9 @@ class LogTestCase(unittest.TestCase):
     def setUp(self):
         # enable propagating to higher loggers
         logger.propagate = 1
-        self.handlers = logger.handlers
-        logger.handlers = []
+        self.handlers = [h for h in logger.handlers]
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
         # add StringIO handler to catch log in need
         log = StringIO()
         new_handler = logging.StreamHandler(log)
@@ -30,7 +31,10 @@ class LogTestCase(unittest.TestCase):
     def tearDown(self):
         # disable propagating to higher loggers
         logger.propagate = 0
-        logger.handlers = self.handlers
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
+        for handler in self.handlers:
+            logger.addHandler(handler)
 
 
 class TempDirTestCase(LogTestCase):

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -39,16 +39,15 @@ class LogTestCase(unittest.TestCase):
 
 class TempDirTestCase(unittest.TestCase):
 
-    def setUp(self, changedir=True):
+    def setUp(self):
         """
         create tmpdir
         """
         self.home = os.getcwd()
         self.tmpdir = tempfile.mkdtemp() + "/"
-        if changedir:
-            os.chdir(self.tmpdir)
+        os.chdir(self.tmpdir)
 
-    def tearDown(self, changedir=True):
+    def tearDown(self):
         if self._resultForDoCleanups.wasSuccessful():
             try:
                 shutil.rmtree(self.tmpdir)
@@ -60,5 +59,4 @@ class TempDirTestCase(unittest.TestCase):
                 % (self._testMethodName, self.tmpdir)
             print(errmsg)
 
-        if changedir:
-            os.chdir(self.home)
+        os.chdir(self.home)

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import tempfile
 import unittest
 import logging
 from StringIO import StringIO
@@ -14,6 +13,10 @@ def initialize_ex(nickname, path, editmode=False):
     ex.ph5open(editmode)
     ex.initgroup()
     return ex
+
+
+def del_files_in_dir(directory):
+    map(os.unlink, (os.path.join(directory, f) for f in os.listdir(directory)))
 
 
 class LogTestCase(unittest.TestCase):
@@ -44,7 +47,8 @@ class TempDirTestCase(unittest.TestCase):
         create tmpdir
         """
         self.home = os.getcwd()
-        self.tmpdir = tempfile.mkdtemp(dir=self.home + '/ph5/test_data/')
+        os.mkdir("ph5/test_data/tmp")
+        self.tmpdir = self.home + "/ph5/test_data/tmp"
         os.chdir(self.tmpdir)
 
     def tearDown(self):

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -778,7 +778,6 @@ class TestPH5API(LogTestCase):
     def test_textural_cut(self):
         """
         tests cutting of text data from arrays
-        using textural_cut method
         """
         # try  das that doesn't exist
         traces = self.ph5API_object.textural_cut('0407',
@@ -835,10 +834,6 @@ class TestPH5API(LogTestCase):
         self.assertFalse(traces)
 
     def test_cut(self):
-        """
-        test regular cut method
-        """
-
         # try cutting das that doesn't exist
         # should return a single trace object with no data
         traces = self.ph5API_object.cut('9999',
@@ -938,9 +933,6 @@ class TestPH5API(LogTestCase):
                          traces[0].data[-1])
 
     def test_get_extent(self):
-        """
-        test get extent functionality
-        """
         # test das that exists
         earliest, latest = self.ph5API_object.get_extent(
             '9EEF',
@@ -1044,9 +1036,6 @@ class TestPH5API(LogTestCase):
         self.assertAlmostEqual(1545085240.922, latest, 5)
 
     def test_get_availability(self):
-        """
-        test get_availability functionality
-        """
         # test das that doesn't exist
         times = self.ph5API_object.get_availability(
             '12345',
@@ -1100,9 +1089,6 @@ class TestPH5API(LogTestCase):
                          times[0])
 
     def test_channels(self):
-        """
-        rest channels method
-        """
         # should give 3 channels
         chans = self.ph5API_object.channels(
             'Array_t_001',
@@ -1201,10 +1187,6 @@ class TestPH5API(LogTestCase):
         self.assertEqual(0, len(das_t))
 
     def test_close_ph5(self):
-        """
-        close ph5 object
-
-        """
         self.ph5API_object.clear()
         self.ph5API_object.close()
         self.assertIsNone(self.ph5API_object.ph5)

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -10,6 +10,7 @@ from ph5.core.tests.test_base import LogTestCase
 
 class TestPH5API(LogTestCase):
     def setUp(self):
+        super(TestPH5API, self).setUp()
         self.ph5API_object = ph5api.PH5(path='ph5/test_data/ph5',
                                         nickname='master.ph5')
 

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -9,9 +9,12 @@ from ph5.core.tests.test_base import LogTestCase
 
 class TestPH5API(LogTestCase):
     def setUp(self):
-        super(TestPH5API, self).setUp()
         self.ph5API_object = ph5api.PH5(path='ph5/test_data/ph5',
                                         nickname='master.ph5')
+
+    def tearDown(self):
+        self.ph5API_object.close()
+        super(TestPH5API, self).tearDown()
 
     def test_load_ph5(self):
         """
@@ -1203,10 +1206,6 @@ class TestPH5API(LogTestCase):
         self.ph5API_object.clear()
         self.ph5API_object.close()
         self.assertIsNone(self.ph5API_object.ph5)
-
-    def tearDown(self):
-        self.ph5API_object.close()
-        super(TestPH5API, self).tearDown()
 
 
 if __name__ == "__main__":

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -1,7 +1,7 @@
 '''
 Tests for ph5api
 '''
-
+import os
 import unittest
 
 from ph5.core import ph5api
@@ -11,8 +11,10 @@ from ph5.core.tests.test_base import LogTestCase
 class TestPH5API(LogTestCase):
     def setUp(self):
         super(TestPH5API, self).setUp()
-        self.ph5API_object = ph5api.PH5(path='ph5/test_data/ph5',
-                                        nickname='master.ph5')
+        self.home = os.getcwd()
+        self.ph5API_object = ph5api.PH5(
+            path=os.path.join(self.home, 'ph5/test_data/ph5'),
+            nickname='master.ph5')
 
     def tearDown(self):
         self.ph5API_object.close()

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -9,12 +9,9 @@ from ph5.core.tests.test_base import LogTestCase
 
 class TestPH5API(LogTestCase):
     def setUp(self):
+        super(TestPH5API, self).setUp()
         self.ph5API_object = ph5api.PH5(path='ph5/test_data/ph5',
                                         nickname='master.ph5')
-
-    def tearDown(self):
-        self.ph5API_object.close()
-        super(TestPH5API, self).tearDown()
 
     def test_load_ph5(self):
         """
@@ -1206,6 +1203,10 @@ class TestPH5API(LogTestCase):
         self.ph5API_object.clear()
         self.ph5API_object.close()
         self.assertIsNone(self.ph5API_object.ph5)
+
+    def tearDown(self):
+        self.ph5API_object.close()
+        super(TestPH5API, self).tearDown()
 
 
 if __name__ == "__main__":

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -9,6 +9,7 @@ from ph5.core.tests.test_base import LogTestCase
 
 class TestPH5API(LogTestCase):
     def setUp(self):
+        super(TestPH5API, self).setUp()
         self.ph5API_object = ph5api.PH5(path='ph5/test_data/ph5',
                                         nickname='master.ph5')
 
@@ -1205,6 +1206,7 @@ class TestPH5API(LogTestCase):
 
     def tearDown(self):
         self.ph5API_object.close()
+        super(TestPH5API, self).tearDown()
 
 
 if __name__ == "__main__":

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -9,7 +9,6 @@ from ph5.core.tests.test_base import LogTestCase
 
 class TestPH5API(LogTestCase):
     def setUp(self):
-        super(TestPH5API, self).setUp()
         self.ph5API_object = ph5api.PH5(path='ph5/test_data/ph5',
                                         nickname='master.ph5')
 

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -3,6 +3,7 @@ Tests for ph5api
 '''
 
 import unittest
+
 from ph5.core import ph5api
 from ph5.core.tests.test_base import LogTestCase
 

--- a/ph5/utilities/metadatatoph5.py
+++ b/ph5/utilities/metadatatoph5.py
@@ -517,6 +517,7 @@ def main():
         metadata.toph5(parsed_array)
 
     ph5_object.ph5close()
+    LOGGER.removeHandler(ch)
 
 
 if __name__ == '__main__':

--- a/ph5/utilities/metadatatoph5.py
+++ b/ph5/utilities/metadatatoph5.py
@@ -517,7 +517,6 @@ def main():
         metadata.toph5(parsed_array)
 
     ph5_object.ph5close()
-    LOGGER.removeHandler(ch)
 
 
 if __name__ == '__main__':

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -12,24 +12,20 @@ from testfixtures import OutputCapture
 
 from ph5.utilities import metadatatoph5
 from ph5.utilities import initialize_ph5
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex
+from ph5.core.tests.test_base import LogTestCase, initialize_ex
 
 
-class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
+class TestMetadatatoPH5(LogTestCase):
     def setUp(self):
-        super(TestMetadatatoPH5, self).setUp(changedir=False)
+        self.path = 'ph5/test_data/miniseedph5'
+        os.mkdir(self.path)
 
-        self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+        self.ph5_object = initialize_ex('master.ph5', self.path, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
         initialize_ph5.set_receiver_t(default_receiver_t)
         os.remove(default_receiver_t)
         self.metadata = metadatatoph5.MetadatatoPH5(
             self.ph5_object)
-
-    def tearDown(self):
-        self.ph5_object.ph5close()
-        super(TestMetadatatoPH5, self).tearDown(changedir=False)
 
     def test_get_args(self):
         """
@@ -317,6 +313,11 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('H', ret[0]['seed_instrument_code_s'])
         self.assertEqual('H', ret[0]['seed_band_code_s'])
         self.assertEqual('N', ret[0]['seed_orientation_code_s'])
+
+    def tearDown(self):
+        self.ph5_object.ph5close()
+        os.remove(os.path.join(self.path, 'master.ph5'))
+        os.removedirs(self.path)
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -19,6 +19,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
         super(TestMetadatatoPH5, self).setUp()
         if self._testMethodName != 'test_main':
+            # not apply for test_main()
             self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
             self.metadata = metadatatoph5.MetadatatoPH5(
                 self.ph5_object)
@@ -54,7 +55,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
-        ph5_object = initialize_ex('master.ph5', '.', True)
+        # create ph5_object to check the result after run main()
+        ph5_object = initialize_ex('master.ph5', '.', False)
         array_names = ph5_object.ph5_g_sorts.names()
         self.assertEqual(
             ['Array_t_001', 'Array_t_002', 'Array_t_003'], array_names)

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -1,17 +1,18 @@
 '''
 Tests for metadatatoph5
 '''
-
-import unittest
-from ph5.utilities import metadatatoph5
-from ph5.utilities import initialize_ph5
-from obspy.core import inventory
-from obspy import UTCDateTime
 import os
 import sys
+import unittest
+
+from obspy.core import inventory
+from obspy import UTCDateTime
 from mock import patch
-from ph5.core.tests.test_base import LogTestCase, initialize_ex
 from testfixtures import OutputCapture
+
+from ph5.utilities import metadatatoph5
+from ph5.utilities import initialize_ph5
+from ph5.core.tests.test_base import LogTestCase, initialize_ex
 
 
 class TestMetadatatoPH5(LogTestCase):

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -16,10 +16,6 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
 
 
 class TestMetadatatoPH5_main(TempDirTestCase, LogTestCase):
-    def tearDown(self):
-        self.ph5_object.ph5close()
-        super(TestMetadatatoPH5_main, self).tearDown()
-
     def test_main(self):
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     os.path.join(self.home,
@@ -56,18 +52,7 @@ class TestMetadatatoPH5_main(TempDirTestCase, LogTestCase):
         self.assertEqual('H', ret[0]['seed_instrument_code_s'])
         self.assertEqual('H', ret[0]['seed_band_code_s'])
         self.assertEqual('N', ret[0]['seed_orientation_code_s'])
-
-
-class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
-    def setUp(self):
-        super(TestMetadatatoPH5, self).setUp()
-        self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
-        self.metadata = metadatatoph5.MetadatatoPH5(
-            self.ph5_object)
-
-    def tearDown(self):
         self.ph5_object.ph5close()
-        super(TestMetadatatoPH5, self).tearDown()
 
     def test_get_args(self):
         with OutputCapture():
@@ -82,6 +67,18 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual(ret.nickname, 'master.ph5')
         self.assertEqual(ret.infile, 'test.xml')
         self.assertEqual(ret.ph5path, '.')
+
+
+class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
+    def setUp(self):
+        super(TestMetadatatoPH5, self).setUp()
+        self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+        self.metadata = metadatatoph5.MetadatatoPH5(
+            self.ph5_object)
+
+    def tearDown(self):
+        self.ph5_object.ph5close()
+        super(TestMetadatatoPH5, self).tearDown()
 
     def test_init(self):
         """

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -11,10 +11,11 @@ from mock import patch
 from testfixtures import OutputCapture
 
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
+    initialize_ex
 
 
-class TestMetadatatoPH5(TempDirTestCase):
+class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
         super(TestMetadatatoPH5, self).setUp()
         if self._testMethodName != 'test_main':
@@ -50,7 +51,8 @@ class TestMetadatatoPH5(TempDirTestCase):
         test main function
         """
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    os.path.join(self.home,
+                                 'ph5/test_data/metadata/station.xml')]
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -98,7 +100,8 @@ class TestMetadatatoPH5(TempDirTestCase):
         tests read_metadata method
         """
         # open file to pass handle
-        f = open("../metadata/station.xml", "r")
+        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
+                 "r")
 
         # should be a stationxml file, valid
         inventory_ = self.metadata.read_metadata(
@@ -118,7 +121,9 @@ class TestMetadatatoPH5(TempDirTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
+        f = open(os.path.join(
+            self.home, "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"),
+            "r")
 
         # should be a dataless SEED file, valid
         inventory_ = self.metadata.read_metadata(
@@ -135,7 +140,8 @@ class TestMetadatatoPH5(TempDirTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open("../metadata/station.txt", "r")
+        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.txt"),
+                 "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -152,7 +158,8 @@ class TestMetadatatoPH5(TempDirTestCase):
                          inventory_[0].stations[4].channels[0].code)
 
         # open file to pass handle
-        f = open("../metadata/array_9_rt125a.kef", "r")
+        f = open(os.path.join(
+            self.home, "ph5/test_data/metadata/array_9_rt125a.kef"), "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -162,7 +169,8 @@ class TestMetadatatoPH5(TempDirTestCase):
         self.assertFalse(inventory_)
 
         # open file to pass handle
-        f = open("../metadata/array_8_130.csv", "r")
+        f = open(os.path.join(
+            self.home, "ph5/test_data/metadata/array_8_130.csv"), "r")
         # should be a CSV, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -172,7 +180,8 @@ class TestMetadatatoPH5(TempDirTestCase):
         self.assertTrue(inventory_)
 
         # unknown file type
-        f = open("../metadata/RESP/125a500_32_RESP", "r")
+        f = open(os.path.join(
+            self.home, "ph5/test_data/metadata/RESP/125a500_32_RESP"), "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -193,7 +202,8 @@ class TestMetadatatoPH5(TempDirTestCase):
         """
         # valid station xml
         # open file to pass handle
-        f = open("../metadata/station.xml", "r")
+        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
+                 "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -241,7 +251,9 @@ class TestMetadatatoPH5(TempDirTestCase):
 
         # test dataless seed
         # should be a dataless SEED file, valid
-        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
+        f = open(os.path.join(
+            self.home,
+            "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"), "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "1B.13.AAA.2018123.dataless")
@@ -269,7 +281,8 @@ class TestMetadatatoPH5(TempDirTestCase):
         """
         test to_ph5 method
         """
-        f = open("../metadata/station.xml", "r")
+        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
+                 "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "station.xml")

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -18,7 +18,7 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
 
 class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        super(TestMetadatatoPH5, self).setUp(changedir=False)
+        super(TestMetadatatoPH5, self).setUp()
 
         self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
@@ -29,7 +29,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
 
     def tearDown(self):
         self.ph5_object.ph5close()
-        super(TestMetadatatoPH5, self).tearDown(changedir=False)
+        super(TestMetadatatoPH5, self).tearDown()
 
     def test_get_args(self):
         """
@@ -53,7 +53,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         test main function
         """
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/metadata/station.xml']
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -102,7 +102,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         tests read_metadata method
         """
         # open file to pass handle
-        f = open("ph5/test_data/metadata/station.xml", "r")
+        f = open("../metadata/station.xml", "r")
 
         # should be a stationxml file, valid
         inventory_ = self.metadata.read_metadata(
@@ -122,8 +122,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open(
-            "ph5/test_data/metadata/1B.13.AAA.2018123.dataless", "r")
+        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
 
         # should be a dataless SEED file, valid
         inventory_ = self.metadata.read_metadata(
@@ -140,8 +139,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open(
-            "ph5/test_data/metadata/station.txt", "r")
+        f = open("../metadata/station.txt", "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -158,8 +156,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[4].channels[0].code)
 
         # open file to pass handle
-        f = open(
-            "ph5/test_data/metadata/array_9_rt125a.kef", "r")
+        f = open("../metadata/array_9_rt125a.kef", "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -169,8 +166,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertFalse(inventory_)
 
         # open file to pass handle
-        f = open(
-            "ph5/test_data/metadata/array_8_130.csv", "r")
+        f = open("../metadata/array_8_130.csv", "r")
         # should be a CSV, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -180,8 +176,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertTrue(inventory_)
 
         # unknown file type
-        f = open(
-            "ph5/test_data/metadata/RESP/125a500_32_RESP", "r")
+        f = open("../metadata/RESP/125a500_32_RESP", "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -202,8 +197,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         # valid station xml
         # open file to pass handle
-        f = open(
-            "ph5/test_data/metadata/station.xml", "r")
+        f = open("../metadata/station.xml", "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -251,8 +245,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
 
         # test dataless seed
         # should be a dataless SEED file, valid
-        f = open(
-            "ph5/test_data/metadata/1B.13.AAA.2018123.dataless", "r")
+        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "1B.13.AAA.2018123.dataless")
@@ -280,8 +273,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         test to_ph5 method
         """
-        f = open(
-            "ph5/test_data/metadata/station.xml", "r")
+        f = open("../metadata/station.xml", "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "station.xml")

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -18,7 +18,7 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
 
 class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        super(TestMetadatatoPH5, self).setUp()
+        super(TestMetadatatoPH5, self).setUp(changedir=False)
 
         self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
@@ -29,7 +29,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
 
     def tearDown(self):
         self.ph5_object.ph5close()
-        super(TestMetadatatoPH5, self).tearDown()
+        super(TestMetadatatoPH5, self).tearDown(changedir=False)
 
     def test_get_args(self):
         """
@@ -53,7 +53,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         test main function
         """
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    'ph5/test_data/metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -102,7 +102,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         tests read_metadata method
         """
         # open file to pass handle
-        f = open("../metadata/station.xml", "r")
+        f = open("ph5/test_data/metadata/station.xml", "r")
 
         # should be a stationxml file, valid
         inventory_ = self.metadata.read_metadata(
@@ -122,7 +122,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
+        f = open(
+            "ph5/test_data/metadata/1B.13.AAA.2018123.dataless", "r")
 
         # should be a dataless SEED file, valid
         inventory_ = self.metadata.read_metadata(
@@ -139,7 +140,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open("../metadata/station.txt", "r")
+        f = open(
+            "ph5/test_data/metadata/station.txt", "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -156,7 +158,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[4].channels[0].code)
 
         # open file to pass handle
-        f = open("../metadata/array_9_rt125a.kef", "r")
+        f = open(
+            "ph5/test_data/metadata/array_9_rt125a.kef", "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -166,7 +169,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertFalse(inventory_)
 
         # open file to pass handle
-        f = open("../metadata/array_8_130.csv", "r")
+        f = open(
+            "ph5/test_data/metadata/array_8_130.csv", "r")
         # should be a CSV, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -176,7 +180,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertTrue(inventory_)
 
         # unknown file type
-        f = open("../metadata/RESP/125a500_32_RESP", "r")
+        f = open(
+            "ph5/test_data/metadata/RESP/125a500_32_RESP", "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -197,7 +202,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         # valid station xml
         # open file to pass handle
-        f = open("../metadata/station.xml", "r")
+        f = open(
+            "ph5/test_data/metadata/station.xml", "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -245,7 +251,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
 
         # test dataless seed
         # should be a dataless SEED file, valid
-        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
+        f = open(
+            "ph5/test_data/metadata/1B.13.AAA.2018123.dataless", "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "1B.13.AAA.2018123.dataless")
@@ -273,7 +280,8 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         test to_ph5 method
         """
-        f = open("../metadata/station.xml", "r")
+        f = open(
+            "ph5/test_data/metadata/station.xml", "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "station.xml")

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -11,11 +11,10 @@ from mock import patch
 from testfixtures import OutputCapture
 
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
-    initialize_ex
+from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
 
 
-class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
+class TestMetadatatoPH5(TempDirTestCase):
     def setUp(self):
         super(TestMetadatatoPH5, self).setUp()
         if self._testMethodName != 'test_main':
@@ -51,8 +50,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         test main function
         """
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    os.path.join(self.home,
-                                 'ph5/test_data/metadata/station.xml')]
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -100,8 +98,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         tests read_metadata method
         """
         # open file to pass handle
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
-                 "r")
+        f = open("../metadata/station.xml", "r")
 
         # should be a stationxml file, valid
         inventory_ = self.metadata.read_metadata(
@@ -121,9 +118,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"),
-            "r")
+        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
 
         # should be a dataless SEED file, valid
         inventory_ = self.metadata.read_metadata(
@@ -140,8 +135,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.txt"),
-                 "r")
+        f = open("../metadata/station.txt", "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -158,8 +152,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[4].channels[0].code)
 
         # open file to pass handle
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/array_9_rt125a.kef"), "r")
+        f = open("../metadata/array_9_rt125a.kef", "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -169,8 +162,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertFalse(inventory_)
 
         # open file to pass handle
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/array_8_130.csv"), "r")
+        f = open("../metadata/array_8_130.csv", "r")
         # should be a CSV, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -180,8 +172,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertTrue(inventory_)
 
         # unknown file type
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/RESP/125a500_32_RESP"), "r")
+        f = open("../metadata/RESP/125a500_32_RESP", "r")
         # should be a KEF, valid
         inventory_ = self.metadata.read_metadata(
             f,
@@ -202,8 +193,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         # valid station xml
         # open file to pass handle
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
-                 "r")
+        f = open("../metadata/station.xml", "r")
 
         # should be a station TXT, valid
         inventory_ = self.metadata.read_metadata(
@@ -251,9 +241,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
 
         # test dataless seed
         # should be a dataless SEED file, valid
-        f = open(os.path.join(
-            self.home,
-            "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"), "r")
+        f = open("../metadata/1B.13.AAA.2018123.dataless", "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "1B.13.AAA.2018123.dataless")
@@ -281,8 +269,7 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         test to_ph5 method
         """
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
-                 "r")
+        f = open("../metadata/station.xml", "r")
         inventory_ = self.metadata.read_metadata(
             f,
             "station.xml")

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -11,11 +11,10 @@ from mock import patch
 from testfixtures import OutputCapture
 
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex
+from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
 
 
-class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
+class TestMetadatatoPH5(TempDirTestCase):
     def setUp(self):
         super(TestMetadatatoPH5, self).setUp()
         if self._testMethodName != 'test_main':

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -15,52 +15,19 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
     initialize_ex
 
 
-class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
-    def setUp(self):
-        super(TestMetadatatoPH5, self).setUp()
-        if self._testMethodName != 'test_main':
-            # the condition exclude test_main() when creating self.ph5_object
-            # because in test_main(), self.ph5_object  have to be created after
-            # the call of main() to check the data added by main()
-            self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
-            self.metadata = metadatatoph5.MetadatatoPH5(
-                self.ph5_object)
-
+class TestMetadatatoPH5_main(TempDirTestCase, LogTestCase):
     def tearDown(self):
         self.ph5_object.ph5close()
-        super(TestMetadatatoPH5, self).tearDown()
-
-    def test_get_args(self):
-        """
-        test get_args
-        """
-        with OutputCapture():
-            with self.assertRaises(SystemExit):
-                metadatatoph5.get_args([])
-            with self.assertRaises(SystemExit):
-                metadatatoph5.get_args(['-n', 'master.ph5'])
-            with self.assertRaises(SystemExit):
-                metadatatoph5.get_args(['-f', 'test.xml'])
-            ret = metadatatoph5.get_args(
-                ['-n', 'master.ph5', '-f', 'test.xml'])
-        self.assertEqual(ret.nickname, 'master.ph5')
-        self.assertEqual(ret.infile, 'test.xml')
-        self.assertEqual(ret.ph5path, '.')
+        super(TestMetadatatoPH5_main, self).tearDown()
 
     def test_main(self):
-        """
-        test main function
-        """
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     os.path.join(self.home,
                                  'ph5/test_data/metadata/station.xml')]
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
-        # This self.ph5_object isn't the repeat of the self.ph5_object in
-        # setUp() because the one in setUp() already excludes test_main().
-        # This self.ph5_object has to be created after
-        # the call of main() to check the data added by main()
+
         self.ph5_object = initialize_ex('master.ph5', '.', False)
         array_names = self.ph5_object.ph5_g_sorts.names()
         self.assertEqual(
@@ -90,6 +57,32 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('H', ret[0]['seed_band_code_s'])
         self.assertEqual('N', ret[0]['seed_orientation_code_s'])
 
+
+class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
+    def setUp(self):
+        super(TestMetadatatoPH5, self).setUp()
+        self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+        self.metadata = metadatatoph5.MetadatatoPH5(
+            self.ph5_object)
+
+    def tearDown(self):
+        self.ph5_object.ph5close()
+        super(TestMetadatatoPH5, self).tearDown()
+
+    def test_get_args(self):
+        with OutputCapture():
+            with self.assertRaises(SystemExit):
+                metadatatoph5.get_args([])
+            with self.assertRaises(SystemExit):
+                metadatatoph5.get_args(['-n', 'master.ph5'])
+            with self.assertRaises(SystemExit):
+                metadatatoph5.get_args(['-f', 'test.xml'])
+            ret = metadatatoph5.get_args(
+                ['-n', 'master.ph5', '-f', 'test.xml'])
+        self.assertEqual(ret.nickname, 'master.ph5')
+        self.assertEqual(ret.infile, 'test.xml')
+        self.assertEqual(ret.ph5path, '.')
+
     def test_init(self):
         """
         test creating metadatatoph5 instance
@@ -99,9 +92,6 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                                    metadatatoph5.MetadatatoPH5))
 
     def test_read_metadata(self):
-        """
-        tests read_metadata method
-        """
         # open file to pass handle
         with open(os.path.join(self.home,
                                "ph5/test_data/metadata/station.xml"),
@@ -185,9 +175,6 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         self.assertFalse(inventory_)
 
     def test_parse_inventory(self):
-        """
-        test parsing inventory
-        """
         # valid station xml
         # open file to pass handle
         with open(os.path.join(self.home,
@@ -263,9 +250,6 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                 datalogger_keys))
 
     def test_to_ph5(self):
-        """
-        test to_ph5 method
-        """
         with open(os.path.join(self.home,
                                "ph5/test_data/metadata/station.xml"),
                   "r") as f:

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -12,20 +12,24 @@ from testfixtures import OutputCapture
 
 from ph5.utilities import metadatatoph5
 from ph5.utilities import initialize_ph5
-from ph5.core.tests.test_base import LogTestCase, initialize_ex
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
+     initialize_ex
 
 
-class TestMetadatatoPH5(LogTestCase):
+class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        self.path = 'ph5/test_data/miniseedph5'
-        os.mkdir(self.path)
+        super(TestMetadatatoPH5, self).setUp(changedir=False)
 
-        self.ph5_object = initialize_ex('master.ph5', self.path, True)
+        self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
         initialize_ph5.set_receiver_t(default_receiver_t)
         os.remove(default_receiver_t)
         self.metadata = metadatatoph5.MetadatatoPH5(
             self.ph5_object)
+
+    def tearDown(self):
+        self.ph5_object.ph5close()
+        super(TestMetadatatoPH5, self).tearDown(changedir=False)
 
     def test_get_args(self):
         """
@@ -313,11 +317,6 @@ class TestMetadatatoPH5(LogTestCase):
         self.assertEqual('H', ret[0]['seed_instrument_code_s'])
         self.assertEqual('H', ret[0]['seed_band_code_s'])
         self.assertEqual('N', ret[0]['seed_orientation_code_s'])
-
-    def tearDown(self):
-        self.ph5_object.ph5close()
-        os.remove(os.path.join(self.path, 'master.ph5'))
-        os.removedirs(self.path)
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -103,14 +103,11 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         tests read_metadata method
         """
         # open file to pass handle
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
-                 "r")
-
-        # should be a stationxml file, valid
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "station.xml")
-        f.close()
+        with open(os.path.join(self.home,
+                               "ph5/test_data/metadata/station.xml"),
+                  "r") as f:
+            # should be a stationxml file, valid
+            inventory_ = self.metadata.read_metadata(f, "station.xml")
         self.assertTrue(inventory_)
         self.assertTrue(isinstance(inventory_,
                                    inventory.Inventory))
@@ -124,15 +121,14 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"),
-            "r")
-
-        # should be a dataless SEED file, valid
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "1B.13.AAA.2018123.dataless")
-        f.close()
+        with open(os.path.join(
+                self.home,
+                "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"),
+                "r") as f:
+            # should be a dataless SEED file, valid
+            inventory_ = self.metadata.read_metadata(
+                f,
+                "1B.13.AAA.2018123.dataless")
         # check that it contains what we think it should
         self.assertEqual(4, len(inventory_[0].stations))
         self.assertEqual('HOL2B',
@@ -143,14 +139,11 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[0].channels[1].code)
 
         # open file to pass handle
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.txt"),
-                 "r")
-
-        # should be a station TXT, valid
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "station.txt")
-        f.close()
+        with open(os.path.join(self.home,
+                               "ph5/test_data/metadata/station.txt"),
+                  "r") as f:
+            # should be a station TXT, valid
+            inventory_ = self.metadata.read_metadata(f, "station.txt")
         # check that it contains what we think it should
         self.assertEqual(397, len(inventory_[0].stations))
         self.assertEqual('1005',
@@ -161,42 +154,34 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
                          inventory_[0].stations[4].channels[0].code)
 
         # open file to pass handle
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/array_9_rt125a.kef"), "r")
-        # should be a KEF, valid
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "array_9_rt125a.kef")
-        f.close()
+        with open(os.path.join(self.home,
+                               "ph5/test_data/metadata/array_9_rt125a.kef"),
+                  "r") as f:
+            # should be a KEF, valid
+            inventory_ = self.metadata.read_metadata(f, "array_9_rt125a.kef")
         # check that it contains what we think it should
         self.assertFalse(inventory_)
 
         # open file to pass handle
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/array_8_130.csv"), "r")
-        # should be a CSV, valid
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "array_8_130.csv")
-        f.close()
+        with open(os.path.join(self.home,
+                               "ph5/test_data/metadata/array_8_130.csv"),
+                  "r") as f:
+            # should be a CSV, valid
+            inventory_ = self.metadata.read_metadata(f, "array_8_130.csv")
         # check that it contains what we think it should
         self.assertTrue(inventory_)
 
         # unknown file type
-        f = open(os.path.join(
-            self.home, "ph5/test_data/metadata/RESP/125a500_32_RESP"), "r")
-        # should be a KEF, valid
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "125a500_32_RESP")
-        f.close()
+        with open(os.path.join(self.home,
+                               "ph5/test_data/metadata/RESP/125a500_32_RESP"),
+                  "r") as f:
+            # should be a KEF, valid
+            inventory_ = self.metadata.read_metadata(f, "125a500_32_RESP")
         # check that it contains what we think it should
         self.assertFalse(inventory_)
 
         # try a closed file handle
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "125a500_32_RESP")
+        inventory_ = self.metadata.read_metadata(f, "125a500_32_RESP")
         self.assertFalse(inventory_)
 
     def test_parse_inventory(self):
@@ -205,14 +190,11 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         # valid station xml
         # open file to pass handle
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
-                 "r")
-
-        # should be a station TXT, valid
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "station.xml")
-        f.close()
+        with open(os.path.join(self.home,
+                               "ph5/test_data/metadata/station.xml"),
+                  "r") as f:
+            # should be a station TXT, valid
+            inventory_ = self.metadata.read_metadata(f, "station.xml")
         parsed_array = self.metadata.parse_inventory(inventory_)
         # expect an array kef with 3 channels HHN, LHN, LOG
         self.assertTrue(parsed_array)
@@ -254,13 +236,13 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
 
         # test dataless seed
         # should be a dataless SEED file, valid
-        f = open(os.path.join(
-            self.home,
-            "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"), "r")
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "1B.13.AAA.2018123.dataless")
-        f.close()
+        with open(os.path.join(
+                self.home,
+                "ph5/test_data/metadata/1B.13.AAA.2018123.dataless"),
+                "r") as f:
+            inventory_ = self.metadata.read_metadata(
+                f,
+                "1B.13.AAA.2018123.dataless")
         parsed_array = self.metadata.parse_inventory(inventory_)
         self.assertTrue(parsed_array)
         self.assertTrue(19, len(parsed_array))
@@ -284,12 +266,10 @@ class TestMetadatatoPH5(TempDirTestCase, LogTestCase):
         """
         test to_ph5 method
         """
-        f = open(os.path.join(self.home, "ph5/test_data/metadata/station.xml"),
-                 "r")
-        inventory_ = self.metadata.read_metadata(
-            f,
-            "station.xml")
-        f.close()
+        with open(os.path.join(self.home,
+                               "ph5/test_data/metadata/station.xml"),
+                  "r") as f:
+            inventory_ = self.metadata.read_metadata(f, "station.xml")
         parsed_array = self.metadata.parse_inventory(inventory_)
         # return true if successful
         self.assertTrue(self.metadata.toph5(parsed_array))

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -12,12 +12,12 @@ from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex
+     initialize_ex, del_files_in_dir
 
 
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        super(TestObspytoPH5, self).setUp(changedir=False)
+        super(TestObspytoPH5, self).setUp()
 
         ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
@@ -35,7 +35,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
 
     def tearDown(self):
         self.obs.ph5.ph5close()
-        super(TestObspytoPH5, self).tearDown(changedir=False)
+        super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
         """
@@ -58,13 +58,13 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         """
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/metadata/station.xml']
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-d',
-                    'ph5/test_data/miniseed/']
+                    '../miniseed/']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -80,26 +80,21 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407LHN.m',
-            ret[1]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407LHN.ms',
+                         ret[1]['raw_file_name_s'])
         ph5_object.ph5close()
-        os.remove('master.ph5')
-        os.remove('miniPH5_00001.ph5')
-        os.remove('metadatatoph5.log')
-        os.remove('datatoph5.log')
+        del_files_in_dir(self.tmpdir)
 
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/metadata/station.xml']
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/miniseed/0407HHN.ms']
+                    '../miniseed/0407HHN.ms']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -115,24 +110,20 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        os.remove('master.ph5')
-        os.remove('miniPH5_00001.ph5')
-        os.remove('metadatatoph5.log')
-        os.remove('datatoph5.log')
+        del_files_in_dir(self.tmpdir)
 
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/metadata/station.xml']
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
         # now make a list for obspytoph5
         f = open("test_list", "w")
-        f.write("ph5/test_data/miniseed/0407HHN.ms")
+        f.write("../miniseed/0407HHN.ms")
         f.close()
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-l',
@@ -152,15 +143,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        os.remove('master.ph5')
-        os.remove('miniPH5_00001.ph5')
-        os.remove('metadatatoph5.log')
-        os.remove('datatoph5.log')
-        os.remove('test_list')
+        # ph5 and log files will be removed in tearDown
 
     def test_to_ph5(self):
         """
@@ -168,7 +154,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         """
         index_t_full = list()
         # try load without metadata
-        entry = "ph5/test_data/miniseed/0407HHN.ms"
+        entry = "../miniseed/0407HHN.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertFalse(index_t)
         self.assertEqual('stop', message)
@@ -176,11 +162,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         # with metadata
         metadata = metadatatoph5.MetadatatoPH5(
             self.obs.ph5)
-        f = open(
-            "ph5/test_data/metadata/station.xml", "r")
-        inventory_ = metadata.read_metadata(
-            f,
-            "station.xml")
+        f = open("../metadata/station.xml", "r")
+        inventory_ = metadata.read_metadata(f, "station.xml")
         f.close()
         parsed_array = metadata.parse_inventory(inventory_)
         metadata.toph5(parsed_array)
@@ -192,7 +175,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             index_t_full.append(e)
 
         # now load LOG CH
-        entry = "ph5/test_data/miniseed/0407LOG.ms"
+        entry = "../miniseed/0407LOG.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertTrue('done', message)
         self.assertTrue(1, len(index_t))
@@ -204,8 +187,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         for entry in index_t_full:
             self.obs.ph5.ph5_g_receivers.populateIndex_t(entry)
         self.obs.update_external_references(index_t_full)
-        self.assertTrue(os.path.isfile(self.tmpdir + "master.ph5"))
-        self.assertTrue(os.path.isfile(self.tmpdir + "miniPH5_00001.ph5"))
+        self.assertTrue(os.path.isfile("master.ph5"))
+        self.assertTrue(os.path.isfile("miniPH5_00001.ph5"))
 
         node = self.obs.ph5.ph5_g_receivers.getdas_g('5553')
         self.obs.ph5.ph5_g_receivers.setcurrent(node)
@@ -217,12 +200,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407LOG.m',
-            ret[1]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407LOG.ms',
+                         ret[1]['raw_file_name_s'])
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -12,7 +12,7 @@ from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex
+     initialize_ex, del_files_in_dir
 
 
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
@@ -52,7 +52,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual(ret.ph5path, '.')
         self.assertTrue(ret.verbose)
 
-    def test_main1(self):
+    def test_main(self):
+        """
+        test main
+        """
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     '../metadata/station.xml']
@@ -82,8 +85,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('../miniseed/0407LHN.ms',
                          ret[1]['raw_file_name_s'])
         ph5_object.ph5close()
+        del_files_in_dir(self.tmpdir)
 
-    def test_main2(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     '../metadata/station.xml']
@@ -110,8 +113,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
+        del_files_in_dir(self.tmpdir)
 
-    def test_main3(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     '../metadata/station.xml']
@@ -143,6 +146,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
+        # ph5 and log files will be removed in tearDown
 
     def test_to_ph5(self):
         """

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -9,7 +9,6 @@ from mock import patch
 from testfixtures import OutputCapture
 
 from ph5.utilities import obspytoph5
-from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
      initialize_ex

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -10,28 +10,26 @@ from testfixtures import OutputCapture
 
 from ph5.utilities import obspytoph5
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
-    initialize_ex
+from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
 
 
-class TestObspytoPH5(TempDirTestCase, LogTestCase):
+class TestObspytoPH5(TempDirTestCase):
     def setUp(self):
         super(TestObspytoPH5, self).setUp()
-        if 'test_main' not in self._testMethodName:
-            # self.ph5_object will be created in test_main1/2/3
-            # after data are added to ph5
-            self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+        if self._testMethodName != 'test_main':
+            # not apply for test_main1,2,3()
+            ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
             self.obs = obspytoph5.ObspytoPH5(
-                self.ph5_object,
+                ph5_object,
                 self.tmpdir,
                 1,
                 1)
             self.obs.verbose = True
-            self.ph5_object.ph5flush()
-            self.ph5_object.ph5_g_sorts.update_local_table_nodes()
+            ph5_object.ph5flush()
+            ph5_object.ph5_g_sorts.update_local_table_nodes()
 
     def tearDown(self):
-        self.ph5_object.ph5close()
+        self.obs.ph5.ph5close()
         super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
@@ -52,8 +50,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def test_main1(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    os.path.join(self.home,
-                                 'ph5/test_data/metadata/station.xml')]
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
@@ -64,10 +61,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        self.ph5_object = initialize_ex('master.ph5', '.', False)
-        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
-        self.ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
+        ph5_object = initialize_ex('master.ph5', '.', False)
+        node = ph5_object.ph5_g_receivers.getdas_g('5553')
+        ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = ph5_object.ph5_g_receivers.read_das()
         keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
                 'array_name_log_a', 'channel_number_i', 'event_number_i',
                 'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
@@ -79,12 +76,12 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                          ret[0]['raw_file_name_s'])
         self.assertEqual('../miniseed/0407LHN.ms',
                          ret[1]['raw_file_name_s'])
+        ph5_object.ph5close()
 
     def test_main2(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    os.path.join(self.home,
-                                 'ph5/test_data/metadata/station.xml')]
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         # first need to run obspytoph5
@@ -94,10 +91,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        self.ph5_object = initialize_ex('master.ph5', '.', False)
-        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
-        self.ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
+        ph5_object = initialize_ex('master.ph5', '.', False)
+        node = ph5_object.ph5_g_receivers.getdas_g('5553')
+        ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = ph5_object.ph5_g_receivers.read_das()
         keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
                 'array_name_log_a', 'channel_number_i', 'event_number_i',
                 'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
@@ -107,12 +104,12 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual(keys, das_keys)
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
+        ph5_object.ph5close()
 
     def test_main3(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    os.path.join(self.home,
-                                 'ph5/test_data/metadata/station.xml')]
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
@@ -127,10 +124,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        self.ph5_object = initialize_ex('master.ph5', '.', False)
-        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
-        self.ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
+        ph5_object = initialize_ex('master.ph5', '.', False)
+        node = ph5_object.ph5_g_receivers.getdas_g('5553')
+        ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = ph5_object.ph5_g_receivers.read_das()
         keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
                 'array_name_log_a', 'channel_number_i', 'event_number_i',
                 'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
@@ -140,6 +137,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual(keys, das_keys)
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
+        ph5_object.ph5close()
 
     def test_to_ph5(self):
         """

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -11,27 +11,31 @@ from testfixtures import OutputCapture
 from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import LogTestCase, initialize_ex
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
+     initialize_ex
 
 
-class TestObspytoPH5(LogTestCase):
+class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        self.path = 'ph5/test_data/miniseedph5'
-        os.mkdir(self.path)
+        super(TestObspytoPH5, self).setUp()
 
-        ph5_object = initialize_ex('master.ph5', self.path, True)
+        ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
         initialize_ph5.set_receiver_t(default_receiver_t)
         os.remove(default_receiver_t)
         ph5_object.initgroup()
         self.obs = obspytoph5.ObspytoPH5(
             ph5_object,
-            self.path,
+            self.tmpdir,
             1,
             1)
         self.obs.verbose = True
         ph5_object.ph5flush()
         ph5_object.ph5_g_sorts.update_local_table_nodes()
+
+    def tearDown(self):
+        self.obs.ph5.ph5close()
+        super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
         """
@@ -48,19 +52,16 @@ class TestObspytoPH5(LogTestCase):
         self.assertEqual(ret.ph5path, '.')
         self.assertTrue(ret.verbose)
 
-    def test_main(self):
-        """
-        test main
-        """
+    def test_main1(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/metadata/station.xml']
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-d',
-                    'ph5/test_data/miniseed/']
+                    '../miniseed/']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -76,26 +77,21 @@ class TestObspytoPH5(LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407LHN.m',
-            ret[1]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407LHN.ms',
+                         ret[1]['raw_file_name_s'])
         ph5_object.ph5close()
-        os.remove('master.ph5')
-        os.remove('miniPH5_00001.ph5')
-        os.remove('metadatatoph5.log')
-        os.remove('datatoph5.log')
 
+    def test_main2(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/metadata/station.xml']
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/miniseed/0407HHN.ms']
+                    '../miniseed/0407HHN.ms']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -111,24 +107,20 @@ class TestObspytoPH5(LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        os.remove('master.ph5')
-        os.remove('miniPH5_00001.ph5')
-        os.remove('metadatatoph5.log')
-        os.remove('datatoph5.log')
 
+    def test_main3(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    'ph5/test_data/metadata/station.xml']
+                    '../metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
         # now make a list for obspytoph5
         f = open("test_list", "w")
-        f.write("ph5/test_data/miniseed/0407HHN.ms")
+        f.write("../miniseed/0407HHN.ms")
         f.close()
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-l',
@@ -148,15 +140,9 @@ class TestObspytoPH5(LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        os.remove('master.ph5')
-        os.remove('miniPH5_00001.ph5')
-        os.remove('metadatatoph5.log')
-        os.remove('datatoph5.log')
-        os.remove('test_list')
 
     def test_to_ph5(self):
         """
@@ -164,7 +150,7 @@ class TestObspytoPH5(LogTestCase):
         """
         index_t_full = list()
         # try load without metadata
-        entry = "ph5/test_data/miniseed/0407HHN.ms"
+        entry = "../miniseed/0407HHN.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertFalse(index_t)
         self.assertEqual('stop', message)
@@ -172,11 +158,8 @@ class TestObspytoPH5(LogTestCase):
         # with metadata
         metadata = metadatatoph5.MetadatatoPH5(
             self.obs.ph5)
-        f = open(
-            "ph5/test_data/metadata/station.xml", "r")
-        inventory_ = metadata.read_metadata(
-            f,
-            "station.xml")
+        f = open("../metadata/station.xml", "r")
+        inventory_ = metadata.read_metadata(f, "station.xml")
         f.close()
         parsed_array = metadata.parse_inventory(inventory_)
         metadata.toph5(parsed_array)
@@ -188,7 +171,7 @@ class TestObspytoPH5(LogTestCase):
             index_t_full.append(e)
 
         # now load LOG CH
-        entry = "ph5/test_data/miniseed/0407LOG.ms"
+        entry = "../miniseed/0407LOG.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertTrue('done', message)
         self.assertTrue(1, len(index_t))
@@ -200,10 +183,8 @@ class TestObspytoPH5(LogTestCase):
         for entry in index_t_full:
             self.obs.ph5.ph5_g_receivers.populateIndex_t(entry)
         self.obs.update_external_references(index_t_full)
-        self.assertTrue(
-            os.path.isfile("ph5/test_data/miniseedph5/master.ph5"))
-        self.assertTrue(
-            os.path.isfile("ph5/test_data/miniseedph5/miniPH5_00001.ph5"))
+        self.assertTrue(os.path.isfile("master.ph5"))
+        self.assertTrue(os.path.isfile("miniPH5_00001.ph5"))
 
         node = self.obs.ph5.ph5_g_receivers.getdas_g('5553')
         self.obs.ph5.ph5_g_receivers.setcurrent(node)
@@ -215,22 +196,10 @@ class TestObspytoPH5(LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407HHN.m',
-            ret[0]['raw_file_name_s'])
-        self.assertEqual(
-            'ph5/test_data/miniseed/0407LOG.m',
-            ret[1]['raw_file_name_s'])
-
-    def tearDown(self):
-        """"""
-        self.obs.ph5.ph5close()
-        os.remove(os.path.join(self.path, 'master.ph5'))
-        try:
-            os.remove(os.path.join(self.path, 'miniPH5_00001.ph5'))
-        except BaseException:
-            pass
-        os.removedirs(self.path)
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407LOG.ms',
+                         ret[1]['raw_file_name_s'])
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -12,12 +12,12 @@ from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex, del_files_in_dir
+     initialize_ex
 
 
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        super(TestObspytoPH5, self).setUp()
+        super(TestObspytoPH5, self).setUp(changedir=False)
 
         ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
@@ -35,7 +35,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
 
     def tearDown(self):
         self.obs.ph5.ph5close()
-        super(TestObspytoPH5, self).tearDown()
+        super(TestObspytoPH5, self).tearDown(changedir=False)
 
     def test_get_args(self):
         """
@@ -58,13 +58,13 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         """
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    'ph5/test_data/metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-d',
-                    '../miniseed/']
+                    'ph5/test_data/miniseed/']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -80,21 +80,26 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual('../miniseed/0407HHN.ms',
-                         ret[0]['raw_file_name_s'])
-        self.assertEqual('../miniseed/0407LHN.ms',
-                         ret[1]['raw_file_name_s'])
+        self.assertEqual(
+            'ph5/test_data/miniseed/0407HHN.m',
+            ret[0]['raw_file_name_s'])
+        self.assertEqual(
+            'ph5/test_data/miniseed/0407LHN.m',
+            ret[1]['raw_file_name_s'])
         ph5_object.ph5close()
-        del_files_in_dir(self.tmpdir)
+        os.remove('master.ph5')
+        os.remove('miniPH5_00001.ph5')
+        os.remove('metadatatoph5.log')
+        os.remove('datatoph5.log')
 
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    'ph5/test_data/metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-f',
-                    '../miniseed/0407HHN.ms']
+                    'ph5/test_data/miniseed/0407HHN.ms']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
@@ -110,20 +115,24 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual('../miniseed/0407HHN.ms',
-                         ret[0]['raw_file_name_s'])
+        self.assertEqual(
+            'ph5/test_data/miniseed/0407HHN.m',
+            ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        del_files_in_dir(self.tmpdir)
+        os.remove('master.ph5')
+        os.remove('miniPH5_00001.ph5')
+        os.remove('metadatatoph5.log')
+        os.remove('datatoph5.log')
 
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    'ph5/test_data/metadata/station.xml']
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
         # now make a list for obspytoph5
         f = open("test_list", "w")
-        f.write("../miniseed/0407HHN.ms")
+        f.write("ph5/test_data/miniseed/0407HHN.ms")
         f.close()
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-l',
@@ -143,10 +152,15 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual('../miniseed/0407HHN.ms',
-                         ret[0]['raw_file_name_s'])
+        self.assertEqual(
+            'ph5/test_data/miniseed/0407HHN.m',
+            ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        # ph5 and log files will be removed in tearDown
+        os.remove('master.ph5')
+        os.remove('miniPH5_00001.ph5')
+        os.remove('metadatatoph5.log')
+        os.remove('datatoph5.log')
+        os.remove('test_list')
 
     def test_to_ph5(self):
         """
@@ -154,7 +168,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         """
         index_t_full = list()
         # try load without metadata
-        entry = "../miniseed/0407HHN.ms"
+        entry = "ph5/test_data/miniseed/0407HHN.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertFalse(index_t)
         self.assertEqual('stop', message)
@@ -162,8 +176,11 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         # with metadata
         metadata = metadatatoph5.MetadatatoPH5(
             self.obs.ph5)
-        f = open("../metadata/station.xml", "r")
-        inventory_ = metadata.read_metadata(f, "station.xml")
+        f = open(
+            "ph5/test_data/metadata/station.xml", "r")
+        inventory_ = metadata.read_metadata(
+            f,
+            "station.xml")
         f.close()
         parsed_array = metadata.parse_inventory(inventory_)
         metadata.toph5(parsed_array)
@@ -175,7 +192,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             index_t_full.append(e)
 
         # now load LOG CH
-        entry = "../miniseed/0407LOG.ms"
+        entry = "ph5/test_data/miniseed/0407LOG.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertTrue('done', message)
         self.assertTrue(1, len(index_t))
@@ -187,8 +204,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         for entry in index_t_full:
             self.obs.ph5.ph5_g_receivers.populateIndex_t(entry)
         self.obs.update_external_references(index_t_full)
-        self.assertTrue(os.path.isfile("master.ph5"))
-        self.assertTrue(os.path.isfile("miniPH5_00001.ph5"))
+        self.assertTrue(os.path.isfile(self.tmpdir + "master.ph5"))
+        self.assertTrue(os.path.isfile(self.tmpdir + "miniPH5_00001.ph5"))
 
         node = self.obs.ph5.ph5_g_receivers.getdas_g('5553')
         self.obs.ph5.ph5_g_receivers.setcurrent(node)
@@ -200,10 +217,12 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual('../miniseed/0407HHN.ms',
-                         ret[0]['raw_file_name_s'])
-        self.assertEqual('../miniseed/0407LOG.ms',
-                         ret[1]['raw_file_name_s'])
+        self.assertEqual(
+            'ph5/test_data/miniseed/0407HHN.m',
+            ret[0]['raw_file_name_s'])
+        self.assertEqual(
+            'ph5/test_data/miniseed/0407LOG.m',
+            ret[1]['raw_file_name_s'])
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -11,31 +11,27 @@ from testfixtures import OutputCapture
 from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex
+from ph5.core.tests.test_base import LogTestCase, initialize_ex
 
 
-class TestObspytoPH5(TempDirTestCase, LogTestCase):
+class TestObspytoPH5(LogTestCase):
     def setUp(self):
-        super(TempDirTestCase, self).setUp()
+        self.path = 'ph5/test_data/miniseedph5'
+        os.mkdir(self.path)
 
-        ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+        ph5_object = initialize_ex('master.ph5', self.path, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
         initialize_ph5.set_receiver_t(default_receiver_t)
         os.remove(default_receiver_t)
         ph5_object.initgroup()
         self.obs = obspytoph5.ObspytoPH5(
             ph5_object,
-            self.tmpdir,
+            self.path,
             1,
             1)
         self.obs.verbose = True
         ph5_object.ph5flush()
         ph5_object.ph5_g_sorts.update_local_table_nodes()
-
-    def tearDown(self):
-        self.obs.ph5.ph5close()
-        super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
         """
@@ -225,6 +221,16 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual(
             'ph5/test_data/miniseed/0407LOG.m',
             ret[1]['raw_file_name_s'])
+
+    def tearDown(self):
+        """"""
+        self.obs.ph5.ph5close()
+        os.remove(os.path.join(self.path, 'master.ph5'))
+        try:
+            os.remove(os.path.join(self.path, 'miniPH5_00001.ph5'))
+        except BaseException:
+            pass
+        os.removedirs(self.path)
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -12,7 +12,7 @@ from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex, del_files_in_dir
+     initialize_ex
 
 
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
@@ -52,10 +52,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual(ret.ph5path, '.')
         self.assertTrue(ret.verbose)
 
-    def test_main(self):
-        """
-        test main
-        """
+    def test_main1(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     '../metadata/station.xml']
@@ -85,8 +82,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('../miniseed/0407LHN.ms',
                          ret[1]['raw_file_name_s'])
         ph5_object.ph5close()
-        del_files_in_dir(self.tmpdir)
 
+    def test_main2(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     '../metadata/station.xml']
@@ -113,8 +110,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        del_files_in_dir(self.tmpdir)
 
+    def test_main3(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
                     '../metadata/station.xml']
@@ -146,7 +143,6 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
         ph5_object.ph5close()
-        # ph5 and log files will be removed in tearDown
 
     def test_to_ph5(self):
         """

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -10,26 +10,28 @@ from testfixtures import OutputCapture
 
 from ph5.utilities import obspytoph5
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
+    initialize_ex
 
 
-class TestObspytoPH5(TempDirTestCase):
+class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
         super(TestObspytoPH5, self).setUp()
-        if self._testMethodName != 'test_main':
-            # not apply for test_main1,2,3()
-            ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+        if 'test_main' not in self._testMethodName:
+            # self.ph5_object will be created in test_main1/2/3
+            # after data are added to ph5
+            self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
             self.obs = obspytoph5.ObspytoPH5(
-                ph5_object,
+                self.ph5_object,
                 self.tmpdir,
                 1,
                 1)
             self.obs.verbose = True
-            ph5_object.ph5flush()
-            ph5_object.ph5_g_sorts.update_local_table_nodes()
+            self.ph5_object.ph5flush()
+            self.ph5_object.ph5_g_sorts.update_local_table_nodes()
 
     def tearDown(self):
-        self.obs.ph5.ph5close()
+        self.ph5_object.ph5close()
         super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
@@ -50,7 +52,8 @@ class TestObspytoPH5(TempDirTestCase):
     def test_main1(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    os.path.join(self.home,
+                                 'ph5/test_data/metadata/station.xml')]
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
@@ -61,10 +64,10 @@ class TestObspytoPH5(TempDirTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = initialize_ex('master.ph5', '.', False)
-        node = ph5_object.ph5_g_receivers.getdas_g('5553')
-        ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = ph5_object.ph5_g_receivers.read_das()
+        self.ph5_object = initialize_ex('master.ph5', '.', False)
+        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
+        self.ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
         keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
                 'array_name_log_a', 'channel_number_i', 'event_number_i',
                 'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
@@ -76,12 +79,12 @@ class TestObspytoPH5(TempDirTestCase):
                          ret[0]['raw_file_name_s'])
         self.assertEqual('../miniseed/0407LHN.ms',
                          ret[1]['raw_file_name_s'])
-        ph5_object.ph5close()
 
     def test_main2(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    os.path.join(self.home,
+                                 'ph5/test_data/metadata/station.xml')]
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         # first need to run obspytoph5
@@ -91,10 +94,10 @@ class TestObspytoPH5(TempDirTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = initialize_ex('master.ph5', '.', False)
-        node = ph5_object.ph5_g_receivers.getdas_g('5553')
-        ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = ph5_object.ph5_g_receivers.read_das()
+        self.ph5_object = initialize_ex('master.ph5', '.', False)
+        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
+        self.ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
         keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
                 'array_name_log_a', 'channel_number_i', 'event_number_i',
                 'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
@@ -104,12 +107,12 @@ class TestObspytoPH5(TempDirTestCase):
         self.assertEqual(keys, das_keys)
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
-        ph5_object.ph5close()
 
     def test_main3(self):
         # first need to run metadatatoph5
         testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    '../metadata/station.xml']
+                    os.path.join(self.home,
+                                 'ph5/test_data/metadata/station.xml')]
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
 
@@ -124,10 +127,10 @@ class TestObspytoPH5(TempDirTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = initialize_ex('master.ph5', '.', False)
-        node = ph5_object.ph5_g_receivers.getdas_g('5553')
-        ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = ph5_object.ph5_g_receivers.read_das()
+        self.ph5_object = initialize_ex('master.ph5', '.', False)
+        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
+        self.ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
         keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
                 'array_name_log_a', 'channel_number_i', 'event_number_i',
                 'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
@@ -137,7 +140,6 @@ class TestObspytoPH5(TempDirTestCase):
         self.assertEqual(keys, das_keys)
         self.assertEqual('../miniseed/0407HHN.ms',
                          ret[0]['raw_file_name_s'])
-        ph5_object.ph5close()
 
     def test_to_ph5(self):
         """

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -17,16 +17,17 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
         super(TestObspytoPH5, self).setUp()
-
-        ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
-        self.obs = obspytoph5.ObspytoPH5(
-            ph5_object,
-            self.tmpdir,
-            1,
-            1)
-        self.obs.verbose = True
-        ph5_object.ph5flush()
-        ph5_object.ph5_g_sorts.update_local_table_nodes()
+        if self._testMethodName != 'test_main':
+            # not apply for test_main1,2,3()
+            ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+            self.obs = obspytoph5.ObspytoPH5(
+                ph5_object,
+                self.tmpdir,
+                1,
+                1)
+            self.obs.verbose = True
+            ph5_object.ph5flush()
+            ph5_object.ph5_g_sorts.update_local_table_nodes()
 
     def tearDown(self):
         self.obs.ph5.ph5close()
@@ -61,7 +62,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = initialize_ex('master.ph5', '.', True)
+        ph5_object = initialize_ex('master.ph5', '.', False)
         node = ph5_object.ph5_g_receivers.getdas_g('5553')
         ph5_object.ph5_g_receivers.setcurrent(node)
         ret, das_keys = ph5_object.ph5_g_receivers.read_das()
@@ -91,7 +92,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = initialize_ex('master.ph5', '.', True)
+        ph5_object = initialize_ex('master.ph5', '.', False)
         node = ph5_object.ph5_g_receivers.getdas_g('5553')
         ph5_object.ph5_g_receivers.setcurrent(node)
         ret, das_keys = ph5_object.ph5_g_receivers.read_das()
@@ -124,7 +125,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = initialize_ex('master.ph5', '.', True)
+        ph5_object = initialize_ex('master.ph5', '.', False)
         node = ph5_object.ph5_g_receivers.getdas_g('5553')
         ph5_object.ph5_g_receivers.setcurrent(node)
         ret, das_keys = ph5_object.ph5_g_receivers.read_das()

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -17,7 +17,7 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
 
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        super(TempDirTestCase, self).setUp()
+        super(TestObspytoPH5, self).setUp(changedir=False)
 
         ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
@@ -35,7 +35,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
 
     def tearDown(self):
         self.obs.ph5.ph5close()
-        super(TestObspytoPH5, self).tearDown()
+        super(TestObspytoPH5, self).tearDown(changedir=False)
 
     def test_get_args(self):
         """
@@ -204,10 +204,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         for entry in index_t_full:
             self.obs.ph5.ph5_g_receivers.populateIndex_t(entry)
         self.obs.update_external_references(index_t_full)
-        self.assertTrue(
-            os.path.isfile("ph5/test_data/miniseedph5/master.ph5"))
-        self.assertTrue(
-            os.path.isfile("ph5/test_data/miniseedph5/miniPH5_00001.ph5"))
+        self.assertTrue(os.path.isfile(self.tmpdir + "master.ph5"))
+        self.assertTrue(os.path.isfile(self.tmpdir + "miniPH5_00001.ph5"))
 
         node = self.obs.ph5.ph5_g_receivers.getdas_g('5553')
         self.obs.ph5.ph5_g_receivers.setcurrent(node)

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -126,11 +126,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.station_xml_path = os.path.join(
             self.home, 'ph5/test_data/metadata/station.xml')
         self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
-        self.obs = obspytoph5.ObspytoPH5(
-            self.ph5_object,
-            self.tmpdir,
-            1,
-            1)
+        self.obs = obspytoph5.ObspytoPH5(self.ph5_object, self.tmpdir, 1, 1)
         self.obs.verbose = True
         self.ph5_object.ph5flush()
         self.ph5_object.ph5_g_sorts.update_local_table_nodes()

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -17,7 +17,7 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
 
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        super(TestObspytoPH5, self).setUp(changedir=False)
+        super(TempDirTestCase, self).setUp()
 
         ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
@@ -35,7 +35,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
 
     def tearDown(self):
         self.obs.ph5.ph5close()
-        super(TestObspytoPH5, self).tearDown(changedir=False)
+        super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
         """
@@ -204,8 +204,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         for entry in index_t_full:
             self.obs.ph5.ph5_g_receivers.populateIndex_t(entry)
         self.obs.update_external_references(index_t_full)
-        self.assertTrue(os.path.isfile(self.tmpdir + "master.ph5"))
-        self.assertTrue(os.path.isfile(self.tmpdir + "miniPH5_00001.ph5"))
+        self.assertTrue(
+            os.path.isfile("ph5/test_data/miniseedph5/master.ph5"))
+        self.assertTrue(
+            os.path.isfile("ph5/test_data/miniseedph5/miniPH5_00001.ph5"))
 
         node = self.obs.ph5.ph5_g_receivers.getdas_g('5553')
         self.obs.ph5.ph5_g_receivers.setcurrent(node)

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -1,15 +1,17 @@
 '''
-Tests for metadatatoph5
+Tests for obspytoph5
 '''
+import os
+import sys
 import unittest
+
+from mock import patch
+from testfixtures import OutputCapture
+
 from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
-import os
 from ph5.utilities import metadatatoph5
-import sys
-from mock import patch
 from ph5.core.tests.test_base import LogTestCase, initialize_ex
-from testfixtures import OutputCapture
 
 
 class TestObspytoPH5(LogTestCase):

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -11,27 +11,31 @@ from testfixtures import OutputCapture
 from ph5.utilities import obspytoph5
 from ph5.utilities import initialize_ph5
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import LogTestCase, initialize_ex
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
+     initialize_ex
 
 
-class TestObspytoPH5(LogTestCase):
+class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
-        self.path = 'ph5/test_data/miniseedph5'
-        os.mkdir(self.path)
+        super(TempDirTestCase, self).setUp()
 
-        ph5_object = initialize_ex('master.ph5', self.path, True)
+        ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
         initialize_ph5.set_receiver_t(default_receiver_t)
         os.remove(default_receiver_t)
         ph5_object.initgroup()
         self.obs = obspytoph5.ObspytoPH5(
             ph5_object,
-            self.path,
+            self.tmpdir,
             1,
             1)
         self.obs.verbose = True
         ph5_object.ph5flush()
         ph5_object.ph5_g_sorts.update_local_table_nodes()
+
+    def tearDown(self):
+        self.obs.ph5.ph5close()
+        super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
         """
@@ -221,16 +225,6 @@ class TestObspytoPH5(LogTestCase):
         self.assertEqual(
             'ph5/test_data/miniseed/0407LOG.m',
             ret[1]['raw_file_name_s'])
-
-    def tearDown(self):
-        """"""
-        self.obs.ph5.ph5close()
-        os.remove(os.path.join(self.path, 'master.ph5'))
-        try:
-            os.remove(os.path.join(self.path, 'miniPH5_00001.ph5'))
-        except BaseException:
-            pass
-        os.removedirs(self.path)
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -134,12 +134,11 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             metadatatoph5.main()
 
         # now make a list for obspytoph5
-        f = open("test_list", "w")
-        # need to use relative path '../miniseed/' because das_t's
-        # 'raw_file_name_s will be chopped off if the path's length is greater
-        # than 32
-        f.write("../miniseed/0407HHN.ms")
-        f.close()
+        with open("test_list", "w") as f:
+            # need to use relative path '../miniseed/0407HHN.ms' because
+            # das_t's 'raw_file_name_s will be chopped off if the path's
+            # length is greater than 32
+            f.write("../miniseed/0407HHN.ms")
         # first need to run obspytoph5
         testargs = ['obspytoph5', '-n', 'master.ph5', '-l',
                     'test_list']
@@ -172,7 +171,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         """
         index_t_full = list()
         # try load without metadata
-        # need to use relative path '../miniseed/' because das_t's
+        # need to use relative path '../miniseed/0407HHN.ms' because das_t's
         # 'raw_file_name_s will be chopped off if the path's length is greater
         # than 32
         entry = "../miniseed/0407HHN.ms"
@@ -182,12 +181,8 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
 
         # with metadata
         metadata = metadatatoph5.MetadatatoPH5(self.obs.ph5)
-        # need to use relative path '../miniseed/' because das_t's
-        # 'raw_file_name_s will be chopped off if the path's length is greater
-        # than 32
-        f = open("../metadata/station.xml", "r")
-        inventory_ = metadata.read_metadata(f, "station.xml")
-        f.close()
+        with open(self.station_xml_path, "r") as f:
+            inventory_ = metadata.read_metadata(f, "station.xml")
         parsed_array = metadata.parse_inventory(inventory_)
         metadata.toph5(parsed_array)
         self.obs.ph5.initgroup()
@@ -198,7 +193,7 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             index_t_full.append(e)
 
         # now load LOG CH
-        # need to use relative path '../miniseed/' because das_t's
+        # need to use relative path '../miniseed/0407LOG.ms' because das_t's
         # 'raw_file_name_s will be chopped off if the path's length is greater
         # than 32
         entry = "../miniseed/0407LOG.ms"

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -10,11 +10,10 @@ from testfixtures import OutputCapture
 
 from ph5.utilities import obspytoph5
 from ph5.utilities import metadatatoph5
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex
+from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
 
 
-class TestObspytoPH5(TempDirTestCase, LogTestCase):
+class TestObspytoPH5(TempDirTestCase):
     def setUp(self):
         super(TestObspytoPH5, self).setUp()
         if self._testMethodName != 'test_main':

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -3,7 +3,6 @@ Tests for obspytoph5
 '''
 import os
 import sys
-import shutil
 import unittest
 
 from mock import patch
@@ -15,44 +14,132 @@ from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
     initialize_ex
 
 
+class TestObspytoPH5_main(TempDirTestCase, LogTestCase):
+    def setUp(self):
+        super(TestObspytoPH5_main, self).setUp()
+        self.station_xml_path = os.path.join(
+            self.home, 'ph5/test_data/metadata/station.xml')
+
+    def tearDown(self):
+        self.ph5_object.ph5close()
+        super(TestObspytoPH5_main, self).tearDown()
+
+    def test_main1(self):
+        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
+                    self.station_xml_path]
+        with patch.object(sys, 'argv', testargs):
+            metadatatoph5.main()
+
+        # need to use relative path '../miniseed/' because das_t's
+        # 'raw_file_name_s will be chopped off if the path's length is greater
+        # than 32
+        testargs = ['obspytoph5', '-n', 'master.ph5', '-d',
+                    '../miniseed/']
+        with patch.object(sys, 'argv', testargs):
+            obspytoph5.main()
+        self.assertTrue(os.path.isfile('master.ph5'))
+        self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
+
+        self.ph5_object = initialize_ex('master.ph5', '.', False)
+        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
+        self.ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
+        keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
+                'array_name_log_a', 'channel_number_i', 'event_number_i',
+                'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
+                'sample_count_i', 'sample_rate_i', 'sample_rate_multiplier_i',
+                'stream_number_i', 'time/ascii_s', 'time/epoch_l',
+                'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
+        self.assertEqual(keys, das_keys)
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407LHN.ms',
+                         ret[1]['raw_file_name_s'])
+
+    def test_main2(self):
+        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
+                    self.station_xml_path]
+        with patch.object(sys, 'argv', testargs):
+            metadatatoph5.main()
+
+        # need to use relative path '../miniseed/' because das_t's
+        # 'raw_file_name_s will be chopped off if the path's length is greater
+        # than 32
+        testargs = ['obspytoph5', '-n', 'master.ph5', '-f',
+                    '../miniseed/0407HHN.ms']
+        with patch.object(sys, 'argv', testargs):
+            obspytoph5.main()
+        self.assertTrue(os.path.isfile('master.ph5'))
+        self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
+
+        self.ph5_object = initialize_ex('master.ph5', '.', False)
+        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
+        self.ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
+        keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
+                'array_name_log_a', 'channel_number_i', 'event_number_i',
+                'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
+                'sample_count_i', 'sample_rate_i', 'sample_rate_multiplier_i',
+                'stream_number_i', 'time/ascii_s', 'time/epoch_l',
+                'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
+        self.assertEqual(keys, das_keys)
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+
+    def test_main3(self):
+        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
+                    self.station_xml_path]
+        with patch.object(sys, 'argv', testargs):
+            metadatatoph5.main()
+
+        with open("test_list", "w") as f:
+            # need to use relative path '../miniseed/0407HHN.ms' because
+            # das_t's 'raw_file_name_s will be chopped off if the path's
+            # length is greater than 32
+            f.write("../miniseed/0407HHN.ms")
+        # first need to run obspytoph5
+        testargs = ['obspytoph5', '-n', 'master.ph5', '-l',
+                    'test_list']
+        with patch.object(sys, 'argv', testargs):
+            obspytoph5.main()
+        self.assertTrue(os.path.isfile('master.ph5'))
+        self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
+
+        self.ph5_object = initialize_ex('master.ph5', '.', False)
+        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
+        self.ph5_object.ph5_g_receivers.setcurrent(node)
+        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
+        keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
+                'array_name_log_a', 'channel_number_i', 'event_number_i',
+                'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
+                'sample_count_i', 'sample_rate_i', 'sample_rate_multiplier_i',
+                'stream_number_i', 'time/ascii_s', 'time/epoch_l',
+                'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
+        self.assertEqual(keys, das_keys)
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+
+
 class TestObspytoPH5(TempDirTestCase, LogTestCase):
     def setUp(self):
         super(TestObspytoPH5, self).setUp()
         self.station_xml_path = os.path.join(
             self.home, 'ph5/test_data/metadata/station.xml')
-        # copy miniseed to tmpdir
-        miniseed_dir = os.path.join(self.home, 'ph5/test_data/miniseed')
-        for filename in os.listdir(miniseed_dir):
-            file_path = os.path.join(miniseed_dir, filename)
-            shutil.copy(file_path, '.')
-
-        if 'test_main' not in self._testMethodName:
-            # the condition exclude test_main1/2/3() when creating
-            # self.ph5_object because in test_main(), self.ph5_object have to
-            # be created after the call of main() to check the data added
-            # by main()
-            self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
-            self.obs = obspytoph5.ObspytoPH5(
-                self.ph5_object,
-                self.tmpdir,
-                1,
-                1)
-            self.obs.verbose = True
-            self.ph5_object.ph5flush()
-            self.ph5_object.ph5_g_sorts.update_local_table_nodes()
+        self.ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
+        self.obs = obspytoph5.ObspytoPH5(
+            self.ph5_object,
+            self.tmpdir,
+            1,
+            1)
+        self.obs.verbose = True
+        self.ph5_object.ph5flush()
+        self.ph5_object.ph5_g_sorts.update_local_table_nodes()
 
     def tearDown(self):
-        try:
-            self.ph5_object.ph5close()
-        except AttributeError:
-            # when test_main() was failed to create self.ph5_object
-            pass
+        self.ph5_object.ph5close()
         super(TestObspytoPH5, self).tearDown()
 
     def test_get_args(self):
-        """
-        test get_args
-        """
         with OutputCapture():
             with self.assertRaises(SystemExit):
                 obspytoph5.get_args([])
@@ -64,110 +151,13 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         self.assertEqual(ret.ph5path, '.')
         self.assertTrue(ret.verbose)
 
-    def test_main1(self):
-        # first need to run metadatatoph5
-        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    self.station_xml_path]
-        with patch.object(sys, 'argv', testargs):
-            metadatatoph5.main()
-
-        # first need to run obspytoph5
-        testargs = ['obspytoph5', '-n', 'master.ph5', '-d', '.']
-        with patch.object(sys, 'argv', testargs):
-            obspytoph5.main()
-        self.assertTrue(os.path.isfile('master.ph5'))
-        self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-
-        # This self.ph5_object isn't the repeat of the self.ph5_object in
-        # setUp() because the one in setUp() already excludes test_main().
-        # This self.ph5_object has to be created after
-        # the call of main() to check the data added by main()
-        self.ph5_object = initialize_ex('master.ph5', '.', False)
-        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
-        self.ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
-        keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
-                'array_name_log_a', 'channel_number_i', 'event_number_i',
-                'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
-                'sample_count_i', 'sample_rate_i', 'sample_rate_multiplier_i',
-                'stream_number_i', 'time/ascii_s', 'time/epoch_l',
-                'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
-        self.assertEqual(keys, das_keys)
-        self.assertEqual('./0407HHN.ms', ret[0]['raw_file_name_s'])
-        self.assertEqual('./0407LHN.ms', ret[1]['raw_file_name_s'])
-
-    def test_main2(self):
-        # first need to run metadatatoph5
-        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    self.station_xml_path]
-        with patch.object(sys, 'argv', testargs):
-            metadatatoph5.main()
-        # first need to run obspytoph5
-        testargs = ['obspytoph5', '-n', 'master.ph5', '-f', '0407HHN.ms']
-        with patch.object(sys, 'argv', testargs):
-            obspytoph5.main()
-        self.assertTrue(os.path.isfile('master.ph5'))
-        self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-
-        # This self.ph5_object isn't the repeat of the self.ph5_object in
-        # setUp() because the one in setUp() already excludes test_main().
-        # This self.ph5_object has to be created after
-        # the call of main() to check the data added by main()
-        self.ph5_object = initialize_ex('master.ph5', '.', False)
-        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
-        self.ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
-        keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
-                'array_name_log_a', 'channel_number_i', 'event_number_i',
-                'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
-                'sample_count_i', 'sample_rate_i', 'sample_rate_multiplier_i',
-                'stream_number_i', 'time/ascii_s', 'time/epoch_l',
-                'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
-        self.assertEqual(keys, das_keys)
-        self.assertEqual('0407HHN.ms', ret[0]['raw_file_name_s'])
-
-    def test_main3(self):
-        # first need to run metadatatoph5
-        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    self.station_xml_path]
-        with patch.object(sys, 'argv', testargs):
-            metadatatoph5.main()
-
-        # now make a list for obspytoph5
-        with open("test_list", "w") as f:
-            f.write("0407HHN.ms")
-        # first need to run obspytoph5
-        testargs = ['obspytoph5', '-n', 'master.ph5', '-l',
-                    'test_list']
-        with patch.object(sys, 'argv', testargs):
-            obspytoph5.main()
-        self.assertTrue(os.path.isfile('master.ph5'))
-        self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-
-        # This self.ph5_object isn't the repeat of the self.ph5_object in
-        # setUp() because the one in setUp() already excludes test_main().
-        # This self.ph5_object has to be created after
-        # the call of main() to check the data added by main()
-        self.ph5_object = initialize_ex('master.ph5', '.', False)
-        node = self.ph5_object.ph5_g_receivers.getdas_g('5553')
-        self.ph5_object.ph5_g_receivers.setcurrent(node)
-        ret, das_keys = self.ph5_object.ph5_g_receivers.read_das()
-        keys = ['array_name_SOH_a', 'array_name_data_a', 'array_name_event_a',
-                'array_name_log_a', 'channel_number_i', 'event_number_i',
-                'raw_file_name_s', 'receiver_table_n_i', 'response_table_n_i',
-                'sample_count_i', 'sample_rate_i', 'sample_rate_multiplier_i',
-                'stream_number_i', 'time/ascii_s', 'time/epoch_l',
-                'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
-        self.assertEqual(keys, das_keys)
-        self.assertEqual('0407HHN.ms', ret[0]['raw_file_name_s'])
-
     def test_to_ph5(self):
-        """
-        test to_ph5
-        """
         index_t_full = list()
         # try load without metadata
-        entry = "0407HHN.ms"
+        # need to use relative path '../miniseed/0407HHN.ms' because das_t's
+        # 'raw_file_name_s will be chopped off if the path's length is greater
+        # than 32
+        entry = "../miniseed/0407HHN.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertFalse(index_t)
         self.assertEqual('stop', message)
@@ -185,8 +175,11 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         for e in index_t:
             index_t_full.append(e)
 
-        # now load LOG CH
-        entry = "0407LOG.ms"
+        # load LOG CH
+        # need to use relative path '../miniseed/0407LOG.ms' because das_t's
+        # 'raw_file_name_s will be chopped off if the path's length is greater
+        # than 32
+        entry = "../miniseed/0407LOG.ms"
         message, index_t = self.obs.toph5((entry, 'MSEED'))
         self.assertTrue('done', message)
         self.assertTrue(1, len(index_t))
@@ -211,8 +204,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
                 'stream_number_i', 'time/ascii_s', 'time/epoch_l',
                 'time/micro_seconds_i', 'time/type_s', 'time_table_n_i']
         self.assertEqual(keys, das_keys)
-        self.assertEqual('0407HHN.ms', ret[0]['raw_file_name_s'])
-        self.assertEqual('0407LOG.ms', ret[1]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407HHN.ms',
+                         ret[0]['raw_file_name_s'])
+        self.assertEqual('../miniseed/0407LOG.ms',
+                         ret[1]['raw_file_name_s'])
 
 
 if __name__ == "__main__":

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -20,10 +20,6 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
         super(TestObspytoPH5, self).setUp()
 
         ph5_object = initialize_ex('master.ph5', self.tmpdir, True)
-        default_receiver_t = initialize_ph5.create_default_receiver_t()
-        initialize_ph5.set_receiver_t(default_receiver_t)
-        os.remove(default_receiver_t)
-        ph5_object.initgroup()
         self.obs = obspytoph5.ObspytoPH5(
             ph5_object,
             self.tmpdir,

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -9,11 +9,10 @@ from mock import patch
 
 from ph5.utilities import segd2ph5, tabletokef
 from ph5.core import segdreader
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \
-     initialize_ex
+from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
 
 
-class TestSegDtoPH5(TempDirTestCase, LogTestCase):
+class TestSegDtoPH5(TempDirTestCase):
 
     def setUp(self):
         super(TestSegDtoPH5, self).setUp()

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -70,13 +70,14 @@ class TestSegDtoPH5(TempDirTestCase, LogTestCase):
         """
         segd2ph5.setLogger()
         segd2ph5.SD = SD = segdreader.Reader(
-            infile=self.home + '/ph5/test_data/segd/3ch.fcnt')
+            infile=os.path.join(self.home + '/ph5/test_data/segd/3ch.fcnt'))
         SD.process_general_headers()
         SD.process_channel_set_descriptors()
         SD.process_extended_headers()
         SD.process_external_headers()
 
-        SIZE = os.path.getsize(self.home + '/ph5/test_data/segd/3ch.fcnt')
+        SIZE = os.path.getsize(
+            os.path.join(self.home + '/ph5/test_data/segd/3ch.fcnt'))
 
         segd2ph5.DAS_INFO = {'3X500': [segd2ph5.Index_t_Info(
             '3X500', './miniPH5_00001.ph5',
@@ -168,7 +169,7 @@ class TestSegDtoPH5(TempDirTestCase, LogTestCase):
         ####################################################################
         # add fcnt data of the same das in the same array but with different
         # deploytime
-        segd_dir = self.home + "/ph5/test_data/segd/"
+        segd_dir = os.path.join(self.home + "/ph5/test_data/segd/")
         # create list file
         list_file = open('fcnt_list', "w")
         fileList = os.listdir(segd_dir)

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -120,7 +120,9 @@ class TestSegDtoPH5(TempDirTestCase, LogTestCase):
 
         SIZE = os.path.getsize(
             os.path.join(self.home, 'ph5/test_data/segd/3ch.fcnt'))
-
+        # need to use relative path './miniPH5_00001.ph5' because
+        # index_t's 'external_file_name_s will be chopped off if the path's
+        # length is greater than 32
         segd2ph5.DAS_INFO = {'3X500': [segd2ph5.Index_t_Info(
             '3X500', './miniPH5_00001.ph5',
             '/Experiment_g/Receivers_g/Das_g_3X500',

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -70,14 +70,14 @@ class TestSegDtoPH5(TempDirTestCase, LogTestCase):
         """
         segd2ph5.setLogger()
         segd2ph5.SD = SD = segdreader.Reader(
-            infile=os.path.join(self.home + '/ph5/test_data/segd/3ch.fcnt'))
+            infile=os.path.join(self.home, 'ph5/test_data/segd/3ch.fcnt'))
         SD.process_general_headers()
         SD.process_channel_set_descriptors()
         SD.process_extended_headers()
         SD.process_external_headers()
 
         SIZE = os.path.getsize(
-            os.path.join(self.home + '/ph5/test_data/segd/3ch.fcnt'))
+            os.path.join(self.home, 'ph5/test_data/segd/3ch.fcnt'))
 
         segd2ph5.DAS_INFO = {'3X500': [segd2ph5.Index_t_Info(
             '3X500', './miniPH5_00001.ph5',
@@ -169,7 +169,7 @@ class TestSegDtoPH5(TempDirTestCase, LogTestCase):
         ####################################################################
         # add fcnt data of the same das in the same array but with different
         # deploytime
-        segd_dir = os.path.join(self.home + "/ph5/test_data/segd/")
+        segd_dir = os.path.join(self.home, "ph5/test_data/segd/")
         # create list file
         list_file = open('fcnt_list', "w")
         fileList = os.listdir(segd_dir)

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -9,11 +9,10 @@ from mock import patch
 
 from ph5.utilities import segd2ph5, tabletokef
 from ph5.core import segdreader
-from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
-    initialize_ex
+from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
 
 
-class TestSegDtoPH5(TempDirTestCase, LogTestCase):
+class TestSegDtoPH5(TempDirTestCase):
 
     def setUp(self):
         super(TestSegDtoPH5, self).setUp()

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -9,10 +9,11 @@ from mock import patch
 
 from ph5.utilities import segd2ph5, tabletokef
 from ph5.core import segdreader
-from ph5.core.tests.test_base import TempDirTestCase, initialize_ex
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase,\
+    initialize_ex
 
 
-class TestSegDtoPH5(TempDirTestCase):
+class TestSegDtoPH5(TempDirTestCase, LogTestCase):
 
     def setUp(self):
         super(TestSegDtoPH5, self).setUp()

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -1,10 +1,12 @@
 '''
 Tests for segd2ph5
 '''
-import unittest
 import os
 import sys
+import unittest
+
 from mock import patch
+
 from ph5.utilities import segd2ph5, tabletokef
 from ph5.core import segdreader
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, \


### PR DESCRIPTION
### What does this PR do?
Standardize unittest by replace current log capture and output capture with testfixtures', assertStrEqual with built-in assertMultiLineEqual.

### Description
ph5/core/tests/test_base.py provide:
 * Function change_logger_handler() : to prevent logs to be printed to console. This will be put in setUpClass() of the tests that have log printed out to screen.
 * Fuction revert_logger_handler(): return logger to original status. This will be put in tearDownClass() of the tests that have change_logger_handler() in setUpClass().
 * class PH5TestCase will call change_logger_handler() in setUpClass() and revert_logger_handler() in tearDownClass so any class that need to prevent logs to be printed to console can extend this class.

assertStrEqual is a function written to compare two long strings to help user identify at which position the two strings are different. However I just figured out that the built-in assertMultiLineEqual can serve that purpose too and works more stable. So I replace assertStrEqual with assertMultiLineEqual.