### PR TITLE
Give meaningful error messages when checking response_t in ph5tostationxml

### DIFF
--- a/ph5/clients/ph5tostationxml.py
+++ b/ph5/clients/ph5tostationxml.py
@@ -17,6 +17,7 @@ from obspy.core import UTCDateTime
 from obspy.core.inventory.response import Response
 from obspy.io.xseed.core import _is_resp
 import pickle
+import tables
 
 from ph5.core import ph5utils, ph5api
 from ph5.core.ph5utils import PH5ResponseManager
@@ -221,6 +222,8 @@ class PH5toStationXMLRequestManager(object):
     """
 
     def __init__(self, sta_xml_obj_list, ph5path, nickname, level, format):
+        self.ph5path = ph5path
+        self.nickname = nickname
         self.request_list = sta_xml_obj_list
         self.ph5 = ph5api.PH5(path=ph5path, nickname=nickname)
         self.iris_custom_ns = "http://www.iris.edu/xml/station/1/"
@@ -288,6 +291,18 @@ class PH5toStationXMLParser(object):
         self.response_table_n_i = None
         self.receiver_table_n_i = None
         self.total_number_stations = 0
+        self.no_resp_file_msg = []
+        self.no_resp_data_msg = []
+        self.all_response_table_n_i_s = []
+        self.manager.ph5.read_response_t()
+        n_i_list = []
+        for entry in self.manager.ph5.Response_t['rows']:
+            n_i_list.append(entry['n_i'])
+        dup_indexes = set([i for i in n_i_list
+                           if n_i_list.count(i) > 1])
+        if len(dup_indexes) != 0:
+            raise PH5toStationXMLError("Response_t n_i duplicated: %s" %
+                                       ','.join(map(str, dup_indexes)))
 
     def is_lat_lon_match(self, sta_xml_obj, latitude, longitude):
         """
@@ -402,29 +417,110 @@ class PH5toStationXMLParser(object):
 
     def get_network(self, path):
         network = self.read_networks(path)
+
         if network:
             network = self.trim_to_level(network)
             return network
         else:
             return
 
-    def get_response_inv(self, obs_channel):
+    def check_resp_data(self, name, device):
+        """
+        Check if response data is loaded for response table's
+        response file name
+        :para name: name of response file
+        :para device: 'das'/'sensor'
+        """
+        path = self.manager.ph5path
+        nickname = self.manager.nickname
+        ph5 = tables.open_file(os.path.join(path, nickname), "r")
+        try:
+            ph5.get_node(ph5.root.Experiment_g.Responses_g, name)
+        except tables.NoSuchNodeError:
+            errmsg = "No response data loaded for %s" % name
+            if errmsg not in self.no_resp_data_msg:
+                self.no_resp_data_msg.append(errmsg)
+            ph5.close()
+            return False
+        ph5.close()
+        return True
+
+    def check_resp_file(self, Response_t, station, chan,
+                        device, name_from_array):
+        """
+        Check response file names in response_t and array_t are matched
+        :para Response_t: response table
+        :para station: station id
+        :para chan: channel info
+        :para device: 'das'/'sensor'
+        :para name_from_array: response file name formed from info in array_t
+        """
+        name_from_response = Response_t['response_file_%s_a' % device]
+        name_from_response_short = name_from_response.split('/')[-1]
+        if (name_from_response_short == ''):
+            if (name_from_array != ''):
+                errmsg = "Response_t's n_i %s: response_file_%s_a "\
+                    "is required." % (self.response_table_n_i, device)
+                if errmsg not in self.no_resp_file_msg:
+                    self.no_resp_file_msg.append(errmsg)
+                return None
+        else:
+            if name_from_array != name_from_response_short:
+                LOGGER.error(
+                    "%s-%s-response_table_n_i %s: "
+                    "Response %s file name should be '%s' "
+                    "while currently is '%s'."
+                    % (station,
+                       chan,
+                       self.response_table_n_i,
+                       device,
+                       name_from_array,
+                       name_from_response_short))
+                return None
+
+        return name_from_response
+
+    def get_response_inv(self, obs_channel, station, chan):
 
         sensor_keys = [obs_channel.sensor.manufacturer,
                        obs_channel.sensor.model]
         datalogger_keys = [obs_channel.data_logger.manufacturer,
                            obs_channel.data_logger.model,
                            obs_channel.sample_rate]
+
         if not self.resp_manager.is_already_requested(sensor_keys,
                                                       datalogger_keys):
             self.manager.ph5.read_response_t()
+
             Response_t = \
                 self.manager.ph5.get_response_t_by_n_i(self.response_table_n_i)
+
             if Response_t:
-                response_file_das_a_name = Response_t.get(
-                    'response_file_das_a', None)
-                response_file_sensor_a_name = Response_t.get(
-                    'response_file_sensor_a', None)
+                das_model = obs_channel.data_logger.model.\
+                    translate(None, ',-=.').replace(" ", "")
+                resp_das_from_info = "%s_%s_%s_%s" % \
+                    (das_model,
+                     int(obs_channel.sample_rate_ration),
+                     int(obs_channel.sample_rate_ration /
+                         obs_channel.sample_rate),
+                     Response_t['gain/value_i'])
+                response_file_das_a_name = self.check_resp_file(
+                    Response_t, station, chan, 'das', resp_das_from_info)
+                if response_file_das_a_name is None:
+                    return Response()
+                if not self.check_resp_data(resp_das_from_info, 'das'):
+                    return Response()
+
+                resp_sensor_from_info = obs_channel.sensor.model.\
+                    translate(None, ',-=.').replace(" ", "")
+                if das_model.startswith("ZLAND"):
+                    resp_sensor_from_info = ""
+                response_file_sensor_a_name = self.check_resp_file(
+                    Response_t, station, chan, 'sensor', resp_sensor_from_info)
+                if response_file_sensor_a_name is None:
+                    return Response()
+                if not self.check_resp_data(resp_das_from_info, 'sensor'):
+                    return Response()
             else:
                 LOGGER.error('Response table not found')
                 return Response()
@@ -502,6 +598,17 @@ class PH5toStationXMLParser(object):
 
     def create_obs_network(self):
         obs_stations = self.read_stations()
+        # ### Sum up errors to limit log messages ###
+        if self.no_resp_file_msg != []:
+            for msg in self.no_resp_file_msg:
+                LOGGER.error(msg)
+        if self.no_resp_data_msg != []:
+            for msg in self.no_resp_data_msg:
+                LOGGER.error(msg)
+        if len(self.all_response_table_n_i_s) == 1:
+            LOGGER.warning("Only one response_table_n_i=%s in array_t."
+                           % self.all_response_table_n_i_s[0])
+        ############################################
         if obs_stations:
             obs_network = inventory.Network(
                 self.experiment_t[0]['net_code_s'])
@@ -760,6 +867,7 @@ class PH5toStationXMLParser(object):
                             all_stations.append(obs_station)
                             self.manager.set_obs_station(sta_key,
                                                          obs_station)
+
         return all_stations
 
     def read_channels(self, sta_xml_obj, station_entry, deployment,
@@ -875,8 +983,12 @@ class PH5toStationXMLParser(object):
                     # read response and add it to obspy channel inventory
                     self.response_table_n_i = \
                         station_entry['response_table_n_i']
+                    if (self.response_table_n_i not in
+                       self.all_response_table_n_i_s):
+                        self.all_response_table_n_i_s.append(
+                            self.response_table_n_i)
                     obs_channel.response = \
-                        self.get_response_inv(obs_channel)
+                        self.get_response_inv(obs_channel, sta_code, cha_code)
 
                     all_channels.append(obs_channel)
         return all_channels
@@ -938,7 +1050,6 @@ def run_ph5_to_stationxml(paths, nickname, out_format,
         pool.terminate()
 
         networks = [n for n in results if n is not None]
-
         if networks:
             inv = inventory.Inventory(
                                         networks=networks,
@@ -999,6 +1110,8 @@ def main():
                 for fname in fileList:
                     if fname == nickname:
                         paths.append(dirName)
+        if paths == []:
+            raise NoDataError("No file found under path(s) {0}.".format(paths))
 
         args_dict_list = [args_dict]
         out_format = args_dict.get('out_format').upper()
@@ -1011,8 +1124,11 @@ def main():
                                     level,
                                     uri,
                                     args_dict_list)
+
         if not inv:
             raise NoDataError("Request resulted in no data.")
+
+        raw_input('Check logs for errors and press any key to continue.')
 
         if out_format == "STATIONXML":
             inv.write(args.outfile,

--- a/ph5/clients/tests/test_ph5tostationxml.py
+++ b/ph5/clients/tests/test_ph5tostationxml.py
@@ -1,0 +1,144 @@
+'''
+Tests for ph5tostationxml
+'''
+import unittest
+import os
+import logging
+import shutil
+import logging
+from ph5.clients import ph5tostationxml
+from ph5.core import ph5api
+from ph5.core.tests.test_base_ import LogTestCase, TempDirTestCase, \
+     initialize_ph5, kef_to_ph5
+from testfixtures import LogCapture
+
+
+class TestPH5toStationXMLParser(LogTestCase, TempDirTestCase):
+    def tearDown(self):
+        super(TestPH5toStationXMLParser, self).tearDown()
+        self.mng.ph5.close()
+
+    def getParser(self, path, nickname, level,
+                  minlat=None, maxlat=None,
+                  minlon=None, maxlon=None,
+                  lat=None, lon=None,
+                  minrad=None, maxrad=None):
+        self.ph5sxml = [ph5tostationxml.PH5toStationXMLRequest(
+            minlatitude=minlat,
+            maxlatitude=maxlat,
+            minlongitude=minlon,
+            maxlongitude=maxlon,
+            latitude=lat,
+            longitude=lon,
+            minradius=minrad,
+            maxradius=maxrad
+        )]
+        self.mng = ph5tostationxml.PH5toStationXMLRequestManager(
+            sta_xml_obj_list=self.ph5sxml,
+            ph5path=".",
+            nickname="master.ph5",
+            level=level,
+            format="TEXT"
+        )
+        return ph5tostationxml.PH5toStationXMLParser(self.mng)
+
+    def test_check_resp_data(self):
+        # copy file
+        shutil.copy(self.home + "/ph5/test_data/ph5/master.ph5", self.tmpdir)
+        parser = self.getParser(".", "master.ph5", "CHANNEL")
+        parser.check_resp_data('rt130_100_1_1')
+        parser.check_resp_data('rt130_200_1_1')
+        parser.check_resp_data('cmg3t')
+        parser.check_resp_data('cmg')
+        self.assertListEqual(parser.unique_errmsg,
+                             ["No response data loaded for rt130_200_1_1",
+                              "No response data loaded for cmg"])
+
+    def test_check_resp_file(self):
+        shutil.copy(self.home + "/ph5/test_data/ph5/master.ph5", self.tmpdir)
+        parser = self.getParser(".", "master.ph5", "CHANNEL")
+        self.ph5 = ph5api.PH5(path='.', nickname='master.ph5')
+        self.ph5.read_response_t()
+        Response_t = self.ph5.get_response_t_by_n_i(4)
+        parser.response_table_n_i = 4
+        # 'rt125a_500_1_32' is response_das_file_name at n_i=4
+        parser.check_resp_file(Response_t, 'STA', 'CHAN', 'das',
+                               'rt125a_500_1_32')
+        # 'rt125a_500_1_1' isn't response_das_file_name at n_i=4
+        with LogCapture() as log:
+            parser.check_resp_file(Response_t, 'STA', 'CHAN', 'das',
+                                   'rt125a_500_1_1')
+        self.assertEqual(log.records[0].msg,
+                         "STA-CHAN-response_table_n_i 4: Response das file "
+                         "name should be 'rt125a_500_1_1' while currently is "
+                         "'rt125a_500_1_32'.")
+
+        # 'gs11v' is response_sensor_file_name at n_i=4
+        parser.check_resp_file(Response_t, 'STA', 'CHAN', 'sensor',
+                               'gs11v')
+        # 'cmg3t' isn't response_sensor_file_name at n_i=4
+        with LogCapture() as log:
+            parser.check_resp_file(Response_t, 'STA', 'CHAN', 'sensor',
+                                   'cmg3t')
+        self.assertEqual(log.records[0].msg,
+                         "STA-CHAN-response_table_n_i 4: Response sensor file "
+                         "name should be 'cmg3t' while currently is "
+                         "'gs11v'.")
+        Response_t = self.ph5.get_response_t_by_n_i(0)
+        parser.response_table_n_i = 0
+        parser.check_resp_file(Response_t, 'STA', 'CHAN', 'sensor',
+                               'gs11v')
+        self.assertListEqual(
+            parser.unique_errmsg,
+            ["Response_t's n_i 0: response_file_sensor_a is required."])
+
+    def test_get_response_inv(self):
+        shutil.copy(self.home + "/ph5/test_data/ph5/master.ph5", self.tmpdir)
+        parser = self.getParser(".", "master.ph5", "CHANNEL")
+        obs_channel = parser.create_obs_channel(
+            sta_code='9001', loc_code='', cha_code='DPZ',
+            start_date='2019-02-22T15:39',
+            end_date='2019-02-22T15:44',
+            cha_longitude=-106.906169, cha_latitude=34.054673,
+            cha_elevation=1403.0,
+            cha_component=1, receiver_id='9001', array_code='009',
+            sample_rate=500.0, sample_rate_ration=500.0,
+            azimuth=0.0, dip=90.0, sensor_manufacturer='geospace',
+            sensor_model='gs11v', sensor_serial='',
+            das_manufacturer='reftek', das_model='rt125a', das_serial='12183'
+        )
+        parser.response_table_n_i = 7
+        parser.get_response_inv(obs_channel, station='9001', chan='DPZ',
+                                samplerate=500.0, samplerate_m=1)
+
+        self.assertListEqual(
+            parser.unique_errmsg,
+            ["response_table_n_i=7 not found in response_t."])
+
+    def test_create_obs_network(self):
+        shutil.copy(self.home + "/ph5/test_data/ph5/master.ph5", self.tmpdir)
+        # ex = initialize_ph5('master.ph5', '.')
+        # ex.ph5_g_responses.nuke_response_t()  # remove response table
+        # kef_to_ph5('.', self.home, ['response_t.kef'], ex, close=False)
+        # need response files that can check:
+        #   + only one response_table_n_i in array_t
+        #   + n_i in Response_t is duplicated
+        #   + wrong Response das filename
+        #   + wrong Response sensor filename
+        #   + No response das filename track from array_t to response_t
+        #   + No response sensor filename track from array_t to response_t
+        #   + No response data loaded for a response file
+        parser = self.getParser(".", "master.ph5", "CHANNEL")
+        
+        parser.manager.ph5.read_experiment_t()
+        parser.experiment_t = parser.manager.ph5.Experiment_t['rows']
+        parser.add_ph5_stationids()
+        with LogCapture() as log:
+            log.setLevel(logging.ERROR)
+            parser.create_obs_network()
+        for l in log.records:
+            print("log2:", l.msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ph5/test_data/metadata/station.xml
+++ b/ph5/test_data/metadata/station.xml
@@ -29,8 +29,8 @@
         <SampleRate>200.0</SampleRate>
         <StorageFormat>PH5</StorageFormat>
         <Sensor>
-          <Type>None CMG-3T</Type>
-          <Description>None CMG-3T/None Q330</Description>
+          <Type>CMG-3T</Type>
+          <Description>CMG-3T/Q330</Description>
           <Manufacturer>None</Manufacturer>
           <Vendor></Vendor>
           <Model>CMG-3T</Model>
@@ -39,7 +39,7 @@
           <RemovalDate>2019-01-14T18:12:04</RemovalDate>
         </Sensor>
         <DataLogger>
-          <Type>None Q330</Type>
+          <Type>Q330</Type>
           <Description></Description>
           <Manufacturer>None</Manufacturer>
           <Vendor></Vendor>
@@ -210,8 +210,8 @@
         <SampleRate>100.0</SampleRate>
         <StorageFormat>PH5</StorageFormat>
         <Sensor>
-          <Type>None CMG-3T</Type>
-          <Description>None CMG-3T/None Q330</Description>
+          <Type>CMG-3T</Type>
+          <Description>CMG-3T/Q330</Description>
           <Manufacturer>None</Manufacturer>
           <Vendor></Vendor>
           <Model>CMG-3T</Model>
@@ -220,7 +220,7 @@
           <RemovalDate>2019-01-14T18:12:04</RemovalDate>
         </Sensor>
         <DataLogger>
-          <Type>None Q330</Type>
+          <Type>Q330</Type>
           <Description></Description>
           <Manufacturer>None</Manufacturer>
           <Vendor></Vendor>
@@ -433,8 +433,8 @@
         <SampleRate>0.0</SampleRate>
         <StorageFormat>PH5</StorageFormat>
         <Sensor>
-          <Type>None CMG-3T</Type>
-          <Description>None CMG-3T/None Q330</Description>
+          <Type>CMG-3T</Type>
+          <Description>CMG-3T/Q330</Description>
           <Manufacturer>None</Manufacturer>
           <Vendor></Vendor>
           <Model>CMG-3T</Model>
@@ -443,7 +443,7 @@
           <RemovalDate>2019-01-14T18:12:05</RemovalDate>
         </Sensor>
         <DataLogger>
-          <Type>None Q330</Type>
+          <Type>Q330</Type>
           <Description></Description>
           <Manufacturer>None</Manufacturer>
           <Vendor></Vendor>


### PR DESCRIPTION
In #334, Akram's 2nd request is to give meaningful error messages in ph5tostationxml, so I created this branch that gives error logs for the following cases:

- Index duplicated: ERROR: Response_t n_i duplicated: 0,2,3,5,6,7,8,9,10,12,13,14,15
- Wrong response_das_filename in Response_t: ERROR: Response das file name should be 'rt130_100_1_1' while currently is 'rt13_100_1_1'.
- Wrong response_sensor_filename in Response_t: ERROR: 601-HDF-response_table_n_i 19: Response sensor file name should be 'Hyperion' while currently is 'Hypeion'.
- No data loaded: ERROR: No response data loaded for ZLAND3C_250_1_12

Before submitting a PR, please review the pull request guidelines:
https://github.com/PIC-IRIS/PH5/blob/master/CONTRIBUTING.md#submitting-a-pull-request

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
