### PR TITLE
Handle temporary directory

### DIFF
--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -1,0 +1,29 @@
+import os
+import shutil
+import unittest
+import tempfile
+
+
+class TempDirTestCase(unittest.TestCase):
+
+    def setUp(self):
+        """
+        create tmpdir
+        """
+        self.home = os.getcwd()
+        self.tmpdir = tempfile.mkdtemp() + "/"
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        if self._resultForDoCleanups.wasSuccessful():
+            try:
+                shutil.rmtree(self.tmpdir)
+            except Exception as e:
+                print("Cannot remove %s due to the error:%s" %
+                      (self.tmpdir, str(e)))
+        else:
+            errmsg = "%s has FAILED. Inspect files created in %s." \
+                % (self._testMethodName, self.tmpdir)
+            print(errmsg)
+
+        os.chdir(self.home)


### PR DESCRIPTION
This PR create TempDirTestCase class in test_base to
 * Create a temporary folder in setUp(). Any files created in testing will be created in this folder.
 * The temporary folder will be deleted in tearDown () if the test pass. Otherwise, a message will be printed to terminal to inform tester that test has been failed and where user can find the temporary folder to inspect.
### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
