### PR TITLE
add initialize_ex to test_base and apply to tests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,6 +93,8 @@ ph5.help
  * calls entry_points to print the short descriptions in alpha-order.
 environment.yml
  * removed unused dependencies and added pykml as a dependency
+ph5.core.tests.test_base
+ * add initialize_ex for creating ph5 experiment object
 
 v4.1.2:
 ph5.utilities.ph5validate

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -11,7 +11,7 @@ def initialize_ex(nickname, path, editmode=False):
     ex.initgroup()
     return ex
 
-  
+
 class TempDirTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -35,4 +35,3 @@ class TempDirTestCase(unittest.TestCase):
             print(errmsg)
 
         os.chdir(self.home)
-

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -1,0 +1,12 @@
+from ph5.core import experiment
+
+
+def initialize_ex(nickname, path, editmode=False):
+    """
+    many test files used this function. However many functional files use this
+    function as well. Wonder if this file should be here.
+    """
+    ex = experiment.ExperimentGroup(nickname=nickname, currentpath=path)
+    ex.ph5open(editmode)
+    ex.initgroup()
+    return ex

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -2,10 +2,6 @@ from ph5.core import experiment
 
 
 def initialize_ex(nickname, path, editmode=False):
-    """
-    many test files used this function. However many functional files use this
-    function as well. Wonder if this file should be here.
-    """
     ex = experiment.ExperimentGroup(nickname=nickname, currentpath=path)
     ex.ph5open(editmode)
     ex.initgroup()

--- a/ph5/utilities/tests/test_metadatatoph5.py
+++ b/ph5/utilities/tests/test_metadatatoph5.py
@@ -4,13 +4,13 @@ Tests for metadatatoph5
 
 import unittest
 from ph5.utilities import metadatatoph5
-from ph5.core import experiment
 from ph5.utilities import initialize_ph5
 from obspy.core import inventory
 from obspy import UTCDateTime
 import os
 import sys
 from mock import patch
+from ph5.core.tests.test_base import initialize_ex
 
 
 class TestMetadatatoPH5(unittest.TestCase):
@@ -24,11 +24,7 @@ class TestMetadatatoPH5(unittest.TestCase):
         else:
             print ("Successfully created the directory %s " % self.path)
 
-        self.ph5_object = experiment.ExperimentGroup(
-            nickname='master.ph5',
-            currentpath=self.path)
-        self.ph5_object.ph5open(True)
-        self.ph5_object.initgroup()
+        self.ph5_object = initialize_ex('master.ph5', self.path, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
         initialize_ph5.set_receiver_t(default_receiver_t)
         os.remove(default_receiver_t)
@@ -59,10 +55,7 @@ class TestMetadatatoPH5(unittest.TestCase):
         with patch.object(sys, 'argv', testargs):
             metadatatoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
-        ph5_object = experiment.ExperimentGroup(
-            nickname='master.ph5')
-        ph5_object.ph5open(True)
-        ph5_object.initgroup()
+        ph5_object = initialize_ex('master.ph5', '.', True)
         array_names = ph5_object.ph5_g_sorts.names()
         self.assertEqual(
             ['Array_t_001', 'Array_t_002', 'Array_t_003'], array_names)

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -3,12 +3,12 @@ Tests for metadatatoph5
 '''
 import unittest
 from ph5.utilities import obspytoph5
-from ph5.core import experiment
 from ph5.utilities import initialize_ph5
 import os
 from ph5.utilities import metadatatoph5
 import sys
 from mock import patch
+from ph5.core.tests.test_base import initialize_ex
 
 
 class TestObspytoPH5(unittest.TestCase):
@@ -22,11 +22,7 @@ class TestObspytoPH5(unittest.TestCase):
         else:
             print ("Successfully created the directory %s " % self.path)
 
-        ph5_object = experiment.ExperimentGroup(
-            nickname='master.ph5',
-            currentpath=self.path)
-        ph5_object.ph5open(True)
-        ph5_object.initgroup()
+        ph5_object = initialize_ex('master.ph5', self.path, True)
         default_receiver_t = initialize_ph5.create_default_receiver_t()
         initialize_ph5.set_receiver_t(default_receiver_t)
         os.remove(default_receiver_t)
@@ -71,10 +67,7 @@ class TestObspytoPH5(unittest.TestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = experiment.ExperimentGroup(
-            nickname='master.ph5')
-        ph5_object.ph5open(True)
-        ph5_object.initgroup()
+        ph5_object = initialize_ex('master.ph5', '.', True)
         node = ph5_object.ph5_g_receivers.getdas_g('5553')
         ph5_object.ph5_g_receivers.setcurrent(node)
         ret, das_keys = ph5_object.ph5_g_receivers.read_das()
@@ -109,10 +102,7 @@ class TestObspytoPH5(unittest.TestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = experiment.ExperimentGroup(
-            nickname='master.ph5')
-        ph5_object.ph5open(True)
-        ph5_object.initgroup()
+        ph5_object = initialize_ex('master.ph5', '.', True)
         node = ph5_object.ph5_g_receivers.getdas_g('5553')
         ph5_object.ph5_g_receivers.setcurrent(node)
         ret, das_keys = ph5_object.ph5_g_receivers.read_das()
@@ -149,10 +139,7 @@ class TestObspytoPH5(unittest.TestCase):
             obspytoph5.main()
         self.assertTrue(os.path.isfile('master.ph5'))
         self.assertTrue(os.path.isfile('miniPH5_00001.ph5'))
-        ph5_object = experiment.ExperimentGroup(
-            nickname='master.ph5')
-        ph5_object.ph5open(True)
-        ph5_object.initgroup()
+        ph5_object = initialize_ex('master.ph5', '.', True)
         node = ph5_object.ph5_g_receivers.getdas_g('5553')
         ph5_object.ph5_g_receivers.setcurrent(node)
         ret, das_keys = ph5_object.ph5_g_receivers.read_das()

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -12,14 +12,10 @@ from mock import patch
 from ph5 import logger, ch as CH
 from ph5.utilities import segd2ph5, tabletokef
 from ph5.core import experiment, segdreader
+from ph5.core.tests.test_base import initialize_ex
 
 
 class TestSegDtoPH5(unittest.TestCase):
-    def initialize_ph5(self, editmode):
-        EX = experiment.ExperimentGroup(nickname="master.ph5")
-        EX.ph5open(editmode)
-        EX.initgroup()
-        return EX
 
     def setUp(self):
         # capture log string into log_capture_string
@@ -34,7 +30,7 @@ class TestSegDtoPH5(unittest.TestCase):
         os.chdir(self.tmpdir)
 
         # initiate ph5
-        self.EX = segd2ph5.EX = self.initialize_ph5(editmode=True)
+        self.EX = segd2ph5.EX = initialize_ex('master.ph5', '.', True)
 
     def tearDown(self):
         try:
@@ -210,7 +206,7 @@ class TestSegDtoPH5(unittest.TestCase):
             segd2ph5.main()
 
         # check that all deploy times are in array_t
-        self.EX = tabletokef.EX = self.initialize_ph5(editmode=False)
+        self.EX = tabletokef.EX = initialize_ex('master.ph5', '.', False)
         tabletokef.ARRAY_T = {}
         tabletokef.read_sort_table()
         tabletokef.read_sort_arrays()

--- a/ph5/utilities/tests/test_segd2ph5.py
+++ b/ph5/utilities/tests/test_segd2ph5.py
@@ -11,7 +11,7 @@ from StringIO import StringIO as StringBuffer
 from mock import patch
 from ph5 import logger, ch as CH
 from ph5.utilities import segd2ph5, tabletokef
-from ph5.core import experiment, segdreader
+from ph5.core import segdreader
 from ph5.core.tests.test_base import initialize_ex
 
 


### PR DESCRIPTION
Add initialize_ex to test_base.py and apply it. However, this function is also repeated in functional PH5 files beside tests. Should we move it to somewhere else like ph5.__init__.py?

### Checklist
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
