### PR TITLE
Fix for ph5availability returning incomplete results.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -85,6 +85,7 @@ ph5.core.tests.test_ph5api
  * unit tests for ph5api
 ph5.core.ph5api
  * fix ph5api cut sometimes returns too many samples (issue #298)
+ * fix for get_availability returning incomplete results
 ph5.entry_points
  * creates a dictionary, keys are names of scripts, 
       values are (1) simple description, 

--- a/ph5/core/ph5api.py
+++ b/ph5/core/ph5api.py
@@ -1454,111 +1454,59 @@ class PH5(experiment.ExperimentGroup):
         if not new_das_t:
             LOGGER.warning("No Das table found for " + das)
             return None
+
+        gaps = 0
         previous = {}
-
-        times = list()
+        times = []
         for entry in new_das_t:
+            # set the values for this entry
+            cur_time = (float(entry['time/epoch_l']) +
+                        float(entry['time/micro_seconds_i']) /
+                        1000000)
+            if entry['sample_rate_i'] > 0:
+                cur_len = (float(entry['sample_count_i']) /
+                           float(entry['sample_rate_i']) /
+                           float(entry['sample_rate_multiplier_i']))
+                cur_sr = (float(entry['sample_rate_i']) /
+                          float(entry['sample_rate_multiplier_i']))
+            else:
+                cur_len = 0
+                cur_sr = 0
+
             if not previous:
-                previous['start'] = (
-                        float(entry['time/epoch_l']) +
-                        float(entry['time/micro_seconds_i']) /
-                        1000000)
-                start_time = previous['start']
-                if entry['sample_rate_i'] > 0:
-                    previous['length'] = (
-                            float(entry['sample_count_i']) /
-                            float(entry['sample_rate_i']) /
-                            float(entry['sample_rate_multiplier_i']))
-                    previous['sample_rate'] = (
-                            float(entry['sample_rate_i']) /
-                            float(entry['sample_rate_multiplier_i']))
-                else:
-                    previous['length'] = 0
-                    previous['sample_rate'] = 0
-
-                previous['end'] = previous['start'] + previous['length']
-                continue
+                previous['start'] = cur_time
+                previous['length'] = cur_len
+                previous['sample_rate'] = cur_sr
+                previous['end'] = cur_time + cur_len
             else:
-
-                if (float(entry['time/epoch_l']) +
-                        float(entry['time/micro_seconds_i']) /
-                        1000000) != previous['start']+previous['length']:
-                    gaps = gaps + 1
+                if cur_time == previous['start'] and \
+                        cur_len == previous['length'] and \
+                        cur_sr == previous['sample_rate']:
+                    # duplicate entry - skip
+                    continue
+                elif cur_time > previous['end'] or \
+                        cur_sr != previous['sample_rate']:
+                    # there is a gap so add a new entry
                     times.append((previous['sample_rate'],
-                                 start_time,
-                                 previous['end']))
-                    previous['start'] = (
-                            float(entry['time/epoch_l']) +
-                            float(entry['time/micro_seconds_i']) /
-                            1000000)
-                    start_time = previous['start']
+                                  previous['start'],
+                                  previous['end']))
+                    # increment the number of gaps and reset previous
+                    gaps = gaps + 1
+                    previous['start'] = cur_time
+                    previous['end'] = cur_time + cur_len
+                    previous['length'] = cur_len
+                    previous['sample_rate'] = cur_sr
+                elif cur_time == previous['end'] and \
+                        cur_sr == previous['sample_rate']:
+                    # extend the end time since this was a continuous segment
+                    previous['end'] = cur_time + cur_len
+                    previous['length'] = cur_len
+                    previous['sample_rate'] = cur_sr
 
-                previous['start'] = (
-                        float(entry['time/epoch_l']) +
-                        float(entry['time/micro_seconds_i']) /
-                        1000000)
-                if entry['sample_rate_i'] > 0:
-                    previous['length'] = (
-                            float(entry['sample_count_i']) /
-                            float(entry['sample_rate_i']) /
-                            float(entry['sample_rate_multiplier_i']))
-                    previous['sample_rate'] = (
-                            float(entry['sample_rate_i']) /
-                            float(entry['sample_rate_multiplier_i']))
-                else:
-                    previous['length'] = 0
-                    previous['sample_rate'] = 0
-
-                previous['end'] = previous['start'] + previous['length']
-        if gaps > 0:
-            start_ = (
-                    float(new_das_t[-1]['time/epoch_l']) +
-                    float(new_das_t[-1]['time/micro_seconds_i']) /
-                    1000000)
-            if new_das_t[-1]['sample_rate_i'] > 0:
-                length_ = (
-                        float(new_das_t[-1]['sample_count_i']) /
-                        float(new_das_t[-1]['sample_rate_i']) /
-                        float(new_das_t[-1]['sample_rate_multiplier_i']))
-                sample_rate_ = (
-                        float(new_das_t[-1]['sample_rate_i']) /
-                        float(new_das_t[-1]['sample_rate_multiplier_i']))
-            else:
-                length_ = 0
-                sample_rate_ = 0
-            end_ = start_ + length_
-            times.append((sample_rate_, start_, end_))
-
-        if gaps == 0:
-            start_time = (
-                    float(new_das_t[0]['time/epoch_l']) +
-                    float(new_das_t[0]['time/micro_seconds_i']) /
-                    1000000)
-            if new_das_t[0]['sample_rate_i'] > 0:
-                sample_rate_ = (
-                        float(new_das_t[0]['sample_rate_i']) /
-                        float(new_das_t[0]['sample_rate_multiplier_i']))
-            else:
-                sample_rate_ = 0
-
-            start_ = (
-                    float(new_das_t[-1]['time/epoch_l']) +
-                    float(new_das_t[-1]['time/micro_seconds_i']) /
-                    1000000)
-            if new_das_t[-1]['sample_rate_i'] > 0:
-                length_ = (
-                        float(new_das_t[-1]['sample_count_i']) /
-                        float(new_das_t[-1]['sample_rate_i']) /
-                        float(new_das_t[-1]['sample_rate_multiplier_i']))
-                sample_rate_ = (
-                        float(new_das_t[-1]['sample_rate_i']) /
-                        float(new_das_t[-1]['sample_rate_multiplier_i']))
-            else:
-                length_ = 0
-                sample_rate_ = 0
-            end_ = start_ + length_
-
-            times.append((sample_rate_, start_time, end_))
+        # add the last continuous segment
+        times.append((previous['sample_rate'],
+                      previous['start'],
+                      previous['end']))
 
         self.forget_das_t(das)
 

--- a/ph5/utilities/1302ph5.py
+++ b/ph5/utilities/1302ph5.py
@@ -254,7 +254,7 @@ def read_par_file(file):
         flds = string.split(line, ';')
 
         if len(flds) != len(order.keys()):
-            LOGGER.error('Error in parameter file: %s'.format(line))
+            LOGGER.error('Error in parameter file: {}'.format(line))
             return False
 
         par = Par()

--- a/ph5/utilities/meta_data_gen.py
+++ b/ph5/utilities/meta_data_gen.py
@@ -102,10 +102,10 @@ def get_args():
                                 formatter_class=argparse.RawTextHelpFormatter)
 
     parser.usage = ("meta-data-gen --nickname=ph5-file-prefix "
-                    "options".format(PROG_VERSION))
+                    "options")
 
     parser.description = ("Write info about receivers, events, or data.\n\n"
-                          "Version: {0}")
+                          "Version: {0}".format(PROG_VERSION))
 
     parser.add_argument("-E", "--experiment", dest="experiment_gen",
                         help="Write info about experiment to stdout,"

--- a/ph5/utilities/metadatatoph5.py
+++ b/ph5/utilities/metadatatoph5.py
@@ -143,7 +143,7 @@ class MetadatatoPH5(object):
                     'ascii', 'ignore')
                 array_station['id_s'] = station.code.encode('ascii',
                                                             'ignore')
-                LOGGER.info('*****************'.format(station.code))
+                LOGGER.info('*****************')
                 LOGGER.info('Found station {0}'.format(station.code))
                 for channel in station:
                     LOGGER.info('Found channel {0}'.format(channel.code))
@@ -313,7 +313,7 @@ class MetadatatoPH5(object):
                     array_list.append(array_dict)
                     LOGGER.info("Loaded channel {0}".format(channel.code))
                 LOGGER.info("Loaded Station {0}".format(station.code))
-                LOGGER.info("******************\n".format(station.code))
+                LOGGER.info("******************\n")
 
         return array_list
 

--- a/ph5/utilities/novenqc.py
+++ b/ph5/utilities/novenqc.py
@@ -388,7 +388,7 @@ def match_type(value, ttype):
             else:
                 return False
         else:
-            print "Unknown type (0) in cfg.".format(ttype)
+            print "Unknown type {0} in cfg.".format(ttype)
     except Exception as e:
         print "Error: ", e.message
         return False

--- a/ph5/utilities/novitiate.py
+++ b/ph5/utilities/novitiate.py
@@ -529,8 +529,7 @@ def churn_recv(recvqc, recvkey):
                     'meters',
                     coordinate_system,
                     'none',
-                    ellipsoid,
-                    '')
+                    ellipsoid)
         # Sensor information
         array_t += '\tsensor/serial_number_s = {0}' \
                    '\n\tsensor/model_s = {1}' \

--- a/ph5/utilities/nuke_table.py
+++ b/ph5/utilities/nuke_table.py
@@ -38,8 +38,7 @@ def get_args():
     parser = argparse.ArgumentParser(
                                 formatter_class=argparse.RawTextHelpFormatter)
 
-    parser.usage = ("delete_table --nickname ph5-file-prefix "
-                    "[options]".format(PROG_VERSION))
+    parser.usage = ("delete_table --nickname ph5-file-prefix [options]")
 
     parser.description = ("Initialize a table in a ph5 file. Caution:"
                           "Deletes contents of table!\n\nVersion: {0}"
@@ -180,10 +179,12 @@ def backup(table_type, table_path, table):
         i += 1
     # Exit if we can't write backup kef
     if os.access(os.getcwd(), os.W_OK):
-        LOGGER.info("Writing table backup: {0}.".format(os.path.join(outfile)))
+        LOGGER.info("Writing table backup: {0}."
+                    .format(os.path.join(os.getcwd(), outfile)))
     else:
         LOGGER.error(
-            "Can't write: {0}.\nExiting!".format(os.getcwd(), outfile))
+            "Can't write: {0}.\nExiting!"
+            .format(os.path.join(os.getcwd(), outfile)))
         sys.exit(-3)
     try:
         fh = open(outfile, 'w')
@@ -191,8 +192,8 @@ def backup(table_type, table_path, table):
         fh.close()
     except Exception:
         LOGGER.error(
-            "Failed to save {0}.\ne.message\nExiting!".format(os.getcwd(),
-                                                              outfile))
+            "Failed to save {0}.\ne.message\nExiting!"
+            .format(os.path.join(os.getcwd(), outfile)))
         sys.exit(-4)
 
 

--- a/ph5/utilities/segy2ph5.py
+++ b/ph5/utilities/segy2ph5.py
@@ -581,7 +581,7 @@ def process_trace(th, bh, rh, eh, tr):
         for t in th:
             keys = sorted(t.keys())
             for k in keys:
-                line = "{1:<80}".format(k, t[k])
+                line = "{0} {1:<80}".format(k, t[k])
                 data.append(line)
 
         EXREC.ph5_g_receivers.newarray(


### PR DESCRIPTION
### What does this PR do?
This PR provides a fix for the ph5availability client returning incomplete time series data availability information.

For example, before this fix the ph5availability client returned the following:

```
ph5) -bash-4.2$ ph5availability -n master.ph5 -p ~/PH5_Experiments/pn4/14-021  -a 2 --station 210 --channel DPZ
#n s    l  c   q                    earliest                      latest
ZI 210  -- DPZ   2014-09-13T20:24:13.000000Z 2014-09-13T20:25:26.000000Z
ZI 210  -- DPZ   2014-10-17T18:00:00.000000Z 2014-10-17T18:59:00.223999Z
```
Notice how the client missed all time series data falling between  `2014-09-13T20:25:26.000000Z` and `2014-10-17T18:00:00.000000Z`.

With this update the command now returns the correct availability information:

```
ph5availability -n master.ph5 -p ~/PH5_Experiments/pn4/14-021  -a 2 --station 210 --channel DPZ
#n s    l  c   q                    earliest                      latest
ZI 210  -- DPZ   2014-09-13T20:24:13.000000Z 2014-09-13T20:25:26.000000Z
ZI 210  -- DPZ   2014-09-13T21:00:00.000000Z 2014-10-17T18:59:00.223999Z
```

### Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [x] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
