### PR TITLE
move changing logger.propagate to where it's needed 

### DIFF
--- a/ph5/clients/tests/test_ph5availability.py
+++ b/ph5/clients/tests/test_ph5availability.py
@@ -13,6 +13,7 @@ from testfixtures import OutputCapture, LogCapture
 from ph5.clients import ph5availability
 from ph5.core import ph5api
 from ph5.core.tests.test_base import LogTestCase, TempDirTestCase
+from ph5 import logger
 
 
 def checkTupleAlmostEqualIn(tup, tupList, place):
@@ -67,6 +68,8 @@ def checkFieldsMatch(fieldNames, fieldsList, dictList):
 class TestPH5Availability(LogTestCase, TempDirTestCase):
     def setUp(self):
         super(TestPH5Availability, self).setUp()
+        # enable propagating to higher loggers
+        logger.propagate = 1
         self.ph5test_path = os.path.join(self.home, 'ph5/test_data/ph5')
         self.ph5_object = ph5api.PH5(
             path=self.ph5test_path,
@@ -76,6 +79,8 @@ class TestPH5Availability(LogTestCase, TempDirTestCase):
 
     def tearDown(self):
         self.ph5_object.close()
+        # disable propagating to higher loggers
+        logger.propagate = 0
         super(TestPH5Availability, self).tearDown()
 
     def test_get_slc(self):

--- a/ph5/core/tests/test_base.py
+++ b/ph5/core/tests/test_base.py
@@ -19,8 +19,6 @@ def initialize_ex(nickname, path, editmode=False):
 class LogTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # enable propagating to higher loggers
-        logger.propagate = 1
         # disable writing log to console
         logger.removeHandler(ch)
         # add StringIO handler to prevent message "No handlers could be found"
@@ -30,8 +28,6 @@ class LogTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # disable propagating to higher loggers
-        logger.propagate = 0
         # revert logger handler
         logger.removeHandler(cls.newch)
         logger.addHandler(ch)


### PR DESCRIPTION
### What does this PR do?
Move the line `logger.propagate = 1 ` to test_ph5availability.py where it is needed to solve the problem it causes for other test.

### Relevant Issues?
When I pulled branch fix328 for PR #357 and ran on my local computer, there was a problem with experiment.py.ExprimentGroup.ph5open() I got the problem that it tried to write on old_tmpdir/test_ph5validate.py. When I remove the line `logger.propagate = 1 ` in test_base.py.LogTestCase.setUpClass the problem was solved.
 
### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
