### PR TITLE
Data ingestion help

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -77,6 +77,7 @@ ph5.utilities.dumpfair
 ph5.utilities.seg2toph5
  * fix bug missing variable
  * Make compatible for pforma
+ * Add flag -r/--raw
 ph5.utilities.pforma_io
  * add seg2 to pforma
  * fix bug that duplicate index_t and array_t when copy tables from A/master.ph5 to Sigma/master.ph5
@@ -90,6 +91,7 @@ ph5.clients.ph5toevt
  * fix info level logging and remove global variables
 ph5.utilities.obspytoph5
  * new tool for loading obspy data in to ph5
+ * change -f to -r, -l to -f to be consistent with other ingestion commands
 ph5.utilities.metadatatoph5
  * new tool for loading stationxml and dataless SEED
 ph5.utilities.tests.test_metadatatoph5

--- a/ph5/utilities/1302ph5.py
+++ b/ph5/utilities/1302ph5.py
@@ -314,19 +314,27 @@ def get_args():
                     " --nickname output_file_prefix")
     parser.description = ("Read a raw rt-130 files into ph5 format. v{0}"
                           .format(PROG_VERSION))
-    parser.add_argument("-r", "--raw", dest="rawfile",
-                        help="RT-130 raw file", metavar="raw_file")
-    parser.add_argument("-f", "--file", dest="infile",
-                        help="File containing list of RT-130 raw file names.",
-                        metavar="file_list_file")
+    parser.epilog = ("Notice: Data of a Das can't be stored in more than one "
+                     "mini file.")
+
+    file_group = parser.add_mutually_exclusive_group()
+    file_group.add_argument("-r", "--raw", dest="rawfile",
+                            help="RT-130 raw file", metavar="raw_file")
+    file_group.add_argument(
+        "-f", "--file", dest="infile",
+        help="File containing list of RT-130 raw file names.",
+        metavar="file_list_file")
+
     parser.add_argument("-n", "--nickname", dest="outfile",
                         help="The ph5 file prefix (experiment nick name).",
                         metavar="output_file_prefix")
-    parser.add_argument("-M", "--num_mini", dest="num_mini",
-                        help="Create a given number miniPH5_xxxxx.ph5 files.",
+    parser.add_argument("-M", "--num_mini",
+                        help=("Create a given number of miniPH5 files."
+                              " Ex: -M 38"),
                         metavar="num_mini", type=int, default=None)
-    parser.add_argument("-S", "--first_mini", dest="first_mini",
-                        help="The index of the first miniPH5_xxxxx.ph5 file.",
+    parser.add_argument("-S", "--first_mini",
+                        help=("The index of the first miniPH5_xxxxx.ph5 "
+                              "file of all. Ex: -S 5"),
                         metavar="first_mini", type=int, default=1)
     parser.add_argument("-s", "--samplerate", dest="samplerate",
                         help="Extract only data at given sample rate.",

--- a/ph5/utilities/obspytoph5.py
+++ b/ph5/utilities/obspytoph5.py
@@ -464,7 +464,9 @@ def get_args(args):
     parser = argparse.ArgumentParser(
             description='Takes data files and converts to PH5',
             usage=('Version: {0} mstoph5 --nickname="Master_PH5_file" '
-                   '[options]'.format(PROG_VERSION))
+                   '[options]'.format(PROG_VERSION)),
+            epilog=("Notice: Data of a Das can't be stored in more than one "
+                    "mini file.")
             )
     parser.add_argument(
         "-n", "--nickname", action="store",
@@ -474,16 +476,17 @@ def get_args(args):
         "-p", "--ph5path", action="store", default=".",
         type=str, metavar="ph5_path")
 
-    parser.add_argument(
+    file_group = parser.add_mutually_exclusive_group()
+    file_group.add_argument(
+        "-r", "--raw", dest="rawfile",
+        default=None,
+        help="Minissed file",
+        metavar="miniseed_file")
+
+    file_group.add_argument(
         "-f", "--file", dest="infile",
         default=None,
-        help="Data file...minissed file",
-        metavar="file_file")
-
-    parser.add_argument(
-        "-l", "--list", dest="inlist",
-        default=None,
-        help="list of data files with full path",
+        help="File containing list of miniseed file names with full path.",
         metavar="file_list_file")
 
     parser.add_argument(
@@ -494,12 +497,13 @@ def get_args(args):
 
     parser.add_argument(
         "-M", "--num_mini", dest="num_mini",
-        help="Create a given number of miniPH5  files.",
+        help="Create a given number of miniPH5  files. Ex: -M 38",
         metavar="num_mini", type=int, default=None)
 
     parser.add_argument(
         "-S", "--first_mini", dest="first_mini",
-        help="The index of the first miniPH5_xxxxx.ph5 file.",
+        help=("The index of the first miniPH5_xxxxx.ph5 "
+              "file of all. Ex: -S 5"),
         metavar="first_mini", type=int, default=1)
 
     parser.add_argument(
@@ -547,18 +551,18 @@ def main():
                     .format(ph5file))
     # Produce list of valid files from file, list, and dirs
     valid_files = list()
-    if args.infile:
-        if _is_mseed(args.infile):
+    if args.rawfile:
+        if _is_mseed(args.rawfile):
             LOGGER.info("{0} is a valid miniSEED file. "
-                        "Adding to process list.".format(args.infile))
-            valid_files.append((args.infile, 'MSEED'))
+                        "Adding to process list.".format(args.rawfile))
+            valid_files.append((args.rawfile, 'MSEED'))
         else:
             LOGGER.info("{0} is a  NOT valid miniSEED file.".format(
-                args.infile))
+                args.rawfile))
 
-    if args.inlist:
+    if args.infile:
         LOGGER.info("Checking list...")
-        with open(args.inlist) as f:
+        with open(args.infile) as f:
             content = f.readlines()
         for line in content:
             if os.path.isfile(line.rstrip()):

--- a/ph5/utilities/seg2toph5.py
+++ b/ph5/utilities/seg2toph5.py
@@ -111,21 +111,30 @@ def get_args():
 
     parser = argparse.ArgumentParser()
     parser.usage = "Version %s seg2toph5 [--help][--raw raw_file |\
-     --file file_list_file] --nickname output_file_prefix" % PROG_VERSION
+        --file file_list_file] --nickname output_file_prefix" % PROG_VERSION
     parser.description = "Read data in SEG-2 revision 1 (StrataVisor)\
-     into ph5 format."
-    parser.add_argument("-f", "--file", dest="infile",
-                        help=("File containing list of absolute paths "
-                              "to SEG-2 file."),
-                        metavar="file_list_file")
+        into ph5 format."
+    parser.epilog = "Notice: Data of a Das can't be stored in more than one \
+        mini file."
+
+    file_group = parser.add_mutually_exclusive_group()
+    file_group.add_argument("-r", "--raw", dest="rawfile",
+                            help="SEG-2 raw file", metavar="raw_file")
+    file_group.add_argument("-f", "--file", dest="infile",
+                            help=("File containing list of absolute paths "
+                                  "to SEG-2 file."),
+                            metavar="file_list_file")
+
     parser.add_argument("-n", "--nickname", dest="outfile",
                         help="The ph5 file prefix (experiment nick name).",
                         metavar="output_file_prefix")
-    parser.add_argument("-M", "--num_mini", dest="num_mini",
-                        help="Create a given number of miniPH5  files.",
+    parser.add_argument("-M", "--num_mini",
+                        help=("Create a given number of miniPH5 files."
+                              " Ex: -M 38"),
                         metavar="num_mini", type=int, default=None)
-    parser.add_argument("-S", "--first_mini", dest="first_mini",
-                        help="The index of the first miniPH5_xxxxx.ph5 file.",
+    parser.add_argument("-S", "--first_mini",
+                        help=("The index of the first miniPH5_xxxxx.ph5 "
+                              "file of all. Ex: -S 5"),
                         metavar="first_mini", type=int, default=1)
     parser.add_argument("-s", "--samplerate", dest="samplerate",
                         help="Extract only data at given sample rate.",
@@ -144,6 +153,9 @@ def get_args():
 
     if args.infile is not None:
         read_infile(args.infile)
+
+    elif args.rawfile is not None:
+        FILES.append(args.rawfile)
 
     if args.outfile is not None:
         PH5 = args.outfile

--- a/ph5/utilities/seg2toph5.py
+++ b/ph5/utilities/seg2toph5.py
@@ -107,7 +107,7 @@ def get_args():
            -M   create a specific number of miniPH5 files
            -S   First index of miniPH5_xxxxx.ph5
     '''
-    global FILES, PH5, SR, NUM_MINI, FIRST_MINI, PATH
+    global FILES, PH5, NUM_MINI, FIRST_MINI, PATH
 
     parser = argparse.ArgumentParser()
     parser.usage = "Version %s seg2toph5 [--help][--raw raw_file |\
@@ -136,9 +136,6 @@ def get_args():
                         help=("The index of the first miniPH5_xxxxx.ph5 "
                               "file of all. Ex: -S 5"),
                         metavar="first_mini", type=int, default=1)
-    parser.add_argument("-s", "--samplerate", dest="samplerate",
-                        help="Extract only data at given sample rate.",
-                        metavar="samplerate")
     parser.add_argument("-p",
                         help="Do print",
                         dest="doprint",
@@ -147,7 +144,6 @@ def get_args():
 
     FILES = []
     PH5 = None
-    SR = args.samplerate
     NUM_MINI = args.num_mini
     FIRST_MINI = args.first_mini
 

--- a/ph5/utilities/segd2ph5.py
+++ b/ph5/utilities/segd2ph5.py
@@ -151,15 +151,19 @@ def get_args():
     from optparse import OptionParser
     oparser = OptionParser()
 
-    oparser.usage = "Version: {0} Usage: segd2ph5 [options]".format(
+    oparser.usage = "Version: {0} Usage: segdtoph5 [options]".format(
         PROG_VERSION)
+    oparser.epilog = ("Notice: Data of a Das can't be stored in more than one "
+                      "mini file.")
 
     oparser.add_option("-r", "--raw", dest="rawfile",
                        help="Fairfield SEG-D v1.6 file.", metavar="raw_file")
 
-    oparser.add_option("-f", action="store", dest="infile", type="string",
+    oparser.add_option("-f", "--file",
+                       action="store", dest="infile", type="string",
                        help="File containing list of Fairfield SEG-D\
-                        v1.6 file names.")
+                        v1.6 file names.",
+                       metavar="file_list_file")
 
     oparser.add_option("-n", "--nickname", dest="outfile",
                        help="The ph5 file prefix (experiment nick name).",
@@ -176,12 +180,14 @@ def get_args():
                        help="Locations are in texas state plane coordinates.",
                        action='store_true', default=False)
 
-    oparser.add_option("-M", "--num_mini", dest="num_mini",
-                       help="Create a given number of miniPH5 files.",
+    oparser.add_option("-M", "--num_mini",
+                       help=("Create a given number of miniPH5 files."
+                             " Ex: -M 38"),
                        metavar="num_mini", type='int', default=None)
 
-    oparser.add_option("-S", "--first_mini", dest="first_mini",
-                       help="The index of the first miniPH5_xxxxx.ph5 file.",
+    oparser.add_option("-S", "--first_mini",
+                       help=("The index of the first miniPH5_xxxxx.ph5 "
+                             "file of all. Ex: -S 5"),
                        metavar="first_mini", type='int', default=1)
 
     oparser.add_option("-c", "--combine", dest="combine",
@@ -200,6 +206,9 @@ def get_args():
                        type='int', default=FAIRFIELD)
 
     options, args = oparser.parse_args()
+
+    if options.rawfile and options.infile:
+        oparser.error("argument -f/--file: not allowed with argument -r/--raw")
 
     FILES = []
     PH5 = None

--- a/ph5/utilities/tests/test_obspytoph5.py
+++ b/ph5/utilities/tests/test_obspytoph5.py
@@ -20,16 +20,16 @@ class TestObspytoPH5_main(TempDirTestCase, LogTestCase):
         super(TestObspytoPH5_main, self).setUp()
         self.station_xml_path = os.path.join(
             self.home, 'ph5/test_data/metadata/station.xml')
+        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
+                    self.station_xml_path]
+        with patch.object(sys, 'argv', testargs):
+            metadatatoph5.main()
 
     def tearDown(self):
         self.ph5_object.ph5close()
         super(TestObspytoPH5_main, self).tearDown()
 
     def test_main1(self):
-        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    self.station_xml_path]
-        with patch.object(sys, 'argv', testargs):
-            metadatatoph5.main()
 
         # need to use relative path '../miniseed/' because das_t's
         # 'raw_file_name_s will be chopped off if the path's length is greater
@@ -58,15 +58,11 @@ class TestObspytoPH5_main(TempDirTestCase, LogTestCase):
                          ret[1]['raw_file_name_s'])
 
     def test_main2(self):
-        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    self.station_xml_path]
-        with patch.object(sys, 'argv', testargs):
-            metadatatoph5.main()
 
         # need to use relative path '../miniseed/' because das_t's
         # 'raw_file_name_s will be chopped off if the path's length is greater
         # than 32
-        testargs = ['obspytoph5', '-n', 'master.ph5', '-f',
+        testargs = ['obspytoph5', '-n', 'master.ph5', '-r',
                     '../miniseed/0407HHN.ms']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
@@ -88,10 +84,6 @@ class TestObspytoPH5_main(TempDirTestCase, LogTestCase):
                          ret[0]['raw_file_name_s'])
 
     def test_main3(self):
-        testargs = ['metadatatoph5', '-n', 'master.ph5', '-f',
-                    self.station_xml_path]
-        with patch.object(sys, 'argv', testargs):
-            metadatatoph5.main()
 
         with open("test_list", "w") as f:
             # need to use relative path '../miniseed/0407HHN.ms' because
@@ -99,7 +91,7 @@ class TestObspytoPH5_main(TempDirTestCase, LogTestCase):
             # length is greater than 32
             f.write("../miniseed/0407HHN.ms")
         # first need to run obspytoph5
-        testargs = ['obspytoph5', '-n', 'master.ph5', '-l',
+        testargs = ['obspytoph5', '-n', 'master.ph5', '-f',
                     'test_list']
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()
@@ -141,10 +133,10 @@ class TestObspytoPH5(TempDirTestCase, LogTestCase):
             with self.assertRaises(SystemExit):
                 obspytoph5.get_args([])
 
-        ret = obspytoph5.get_args(['-n', 'master.ph5', '-f', 'test.ms',
+        ret = obspytoph5.get_args(['-n', 'master.ph5', '-r', 'test.ms',
                                    '-V'])
         self.assertEqual(ret.nickname, 'master.ph5')
-        self.assertEqual(ret.infile, 'test.ms')
+        self.assertEqual(ret.rawfile, 'test.ms')
         self.assertEqual(ret.ph5path, '.')
         self.assertTrue(ret.verbose)
 
@@ -229,7 +221,7 @@ class TestObspytoPH5_float32(TempDirTestCase, LogTestCase):
         super(TestObspytoPH5_float32, self).tearDown()
 
     def test_main(self):
-        testargs = ['mstoph5', '-n', 'master.ph5', '-f',
+        testargs = ['mstoph5', '-n', 'master.ph5', '-r',
                     os.path.join(self.datapath, '05743.SS..GHZ.148')]
         with patch.object(sys, 'argv', testargs):
             obspytoph5.main()

--- a/ph5/utilities/texan2ph5.py
+++ b/ph5/utilities/texan2ph5.py
@@ -173,23 +173,31 @@ def get_args():
                     .format(PROG_VERSION))
     parser.description = ("Read a raw texan files and optionally a kef "
                           "file into ph5 format.")
-    parser.add_argument("-r", "--raw", dest="rawfile",
-                        help="RT-125(a) texan raw file", metavar="raw_file")
-    parser.add_argument("-f", "--file", dest="infile",
-                        help=("File containing list of RT-125(a) "
-                              "raw file names."),
-                        metavar="file_list_file")
+    parser.epilog = ("Notice: Data of a Das can't be stored in more than one "
+                     "mini file.")
+
+    file_group = parser.add_mutually_exclusive_group()
+    file_group.add_argument("-r", "--raw", dest="rawfile",
+                            help="RT-125(a) texan raw file",
+                            metavar="raw_file")
+    file_group.add_argument("-f", "--file", dest="infile",
+                            help=("File containing list of RT-125(a) "
+                                  "raw file names."),
+                            metavar="file_list_file")
+
     parser.add_argument("-o", "--overide", dest="overide",
                         help="Overide file name checks.",
                         action="store_true", default=False)
     parser.add_argument("-n", "--nickname", dest="outfile",
                         help="The ph5 file prefix (experiment nick name).",
                         metavar="output_file_prefix")
-    parser.add_argument("-M", "--num_mini", dest="num_mini",
-                        help="Create given number of miniPH5_xxxxx.ph5 files.",
+    parser.add_argument("-M", "--num_mini",
+                        help=("Create a given number of miniPH5 files."
+                              " Ex: -M 38"),
                         metavar="num_mini", type=int, default=None)
-    parser.add_argument("-S", "--first_mini", dest="first_mini",
-                        help="The index of the first miniPH5_xxxxx.ph5 file.",
+    parser.add_argument("-S", "--first_mini",
+                        help=("The index of the first miniPH5_xxxxx.ph5 "
+                              "file of all. Ex: -S 5"),
                         metavar="first_mini", type=int, default=1)
     parser.add_argument("-s", "--samplerate", dest="samplerate",
                         help="Extract only data at given sample rate.",


### PR DESCRIPTION
### What does this PR do?
Related to issue #393: Replace #429, #426 because those PR cannot continue due to Das_t structure. Some requested changes in help of ingestion commands will be fulfill here.
- Add example for flags -S and -M
- Add "Notice: Data of a Das can't be stored in more than one mini file." into epilog of commands' help
- Add check for flag -r and -f so they can't be used with each other
- Add flag -r to seg2toph5
- Make mstoph5 consistent with other ingestion commands by changing -f to -r, -l to -f

Related to issue #275: sample rate will not be implemented for seg2toph5 so this PR will remove the flag -s from the command

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
