### PR TITLE
Correcting inconsistently changing sample rate multiplier in experiment.py and ph5api.py

### DIFF
--- a/ph5/clients/tests/test_ph5toms.py
+++ b/ph5/clients/tests/test_ph5toms.py
@@ -3,8 +3,20 @@ Tests for ph5toms
 '''
 
 import unittest
-from ph5.clients.ph5toms import StationCut, PH5toMSeed
 import copy
+import os
+import sys
+import itertools
+from StringIO import StringIO
+
+from mock import patch
+from testfixtures import OutputCapture
+from obspy.core import UTCDateTime
+
+from ph5.utilities import initialize_ph5, segd2ph5, nuke_table, kef2ph5
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase
+from ph5.core import ph5api
+from ph5.clients.ph5toms import StationCut, PH5toMSeed
 
 
 class RestrictedRequest(object):
@@ -202,6 +214,105 @@ class TestPH5toMSeed(unittest.TestCase):
         result = PH5toMSeed.get_nonrestricted_segments(
             station_to_cut_list, restricted_list)
         self.assertEqual(result[0].__dict__, expected.__dict__)
+
+
+class TestPH5toMSeed_srm(LogTestCase, TempDirTestCase):
+    def setUp(self):
+        super(TestPH5toMSeed_srm, self).setUp()
+        segdpath = os.path.join(self.home, 'ph5/test_data/segd/1111.0.0.fcnt')
+        kefpath = os.path.join(self.home,
+                               'ph5/test_data/segd/Das_t_1X1111.0.0_SRM0.kef')
+        testargs = ['initialize_ph5', '-n', 'master.ph5']
+        with patch.object(sys, 'argv', testargs):
+            initialize_ph5.main()
+
+        testargs = ['segdtoph5', '-n', 'master.ph5', '-r', segdpath]
+        with patch.object(sys, 'argv', testargs):
+            segd2ph5.main()
+
+        # delete_table and keftoph5 to replace das table's
+        # sample_rate_multiplier=0 for testing
+        testargs = ['delete_table', '-n', 'master.ph5', '-D', '1X1111']
+        with patch.object(sys, 'argv', testargs):
+            with OutputCapture():
+                f = StringIO('y')
+                sys.stdin = f
+                nuke_table.main()
+                f.close()
+
+        testargs = ['keftoph5', '-n', 'master.ph5', '-k', kefpath]
+        with patch.object(sys, 'argv', testargs):
+            kef2ph5.main()
+
+        self.ph5_object = ph5api.PH5(path=self.tmpdir, nickname='master.ph5')
+        self.ph5ms = PH5toMSeed(self.ph5_object,
+                                starttime='2019-06-29T18:03:13.000000')
+
+    def tearDown(self):
+        self.ph5_object.close()
+        super(TestPH5toMSeed_srm, self).tearDown()
+
+    def test_create_trace(self):
+        seed_network = 'AA'
+        ph5_station = '1111'
+        seed_station = '1111'
+        station_cut_times = []
+        self.ph5ms.read_arrays('Array_t_001')
+        arraybyid = self.ph5_object.Array_t['Array_t_001']['byid']
+        station_list = arraybyid.get(ph5_station)
+        deployment = 1
+        st_num = 0
+        array_code = '001'
+        experiment_id = '99-999'
+        cut = self.ph5ms.create_cut(
+            seed_network, ph5_station, seed_station, station_cut_times,
+            station_list, deployment, st_num, array_code, experiment_id)
+
+        cuts = itertools.chain.from_iterable([cut])
+
+        # test cut time in days
+        time_cut_in_day = [
+            (1561831393, 1561852800), (1561852800, 1561939200),
+            (1561939200, 1562025600), (1562025600, 1562112000),
+            (1562112000, 1562198400), (1562198400, 1562284800),
+            (1562284800, 1562371200), (1562371200, 1562457600),
+            (1562457600, 1562544000), (1562544000, 1562630400),
+            (1562630400, 1562716800), (1562716800, 1562803200),
+            (1562803200, 1562889600), (1562889600, 1562976000),
+            (1562976000, 1563062400), (1563062400, 1563148800),
+            (1563148800, 1563235200), (1563235200, 1563321600),
+            (1563321600, 1563408000), (1563408000, 1563494400),
+            (1563494400, 1563580800), (1563580800, 1563633604.726999)]
+        trace_times = [(UTCDateTime(2019, 7, 4, 16, 0, 0, 329998),
+                        UTCDateTime(2019, 7, 4, 16, 0, 30, 328998)),
+                       (UTCDateTime(2019, 7, 4, 16, 0, 30, 329998),
+                        UTCDateTime(2019, 7, 4, 16, 1, 0, 328998)),
+                       (UTCDateTime(2019, 7, 4, 16, 1, 0, 329998),
+                        UTCDateTime(2019, 7, 4, 16, 1, 30, 328998))]
+        count_time_cut = 0
+        count_stream = 0
+        count_trace = 0
+        # Before converting srm=0 in ph5api.PH5.query_das_t() to 1
+        # all streams are None.
+        # After converting, there is one stream with 3 traces
+        for c in cuts:
+            self.assertEqual((c.starttime, c.endtime),
+                             time_cut_in_day[count_time_cut])
+            stream = self.ph5ms.create_trace(c)
+            if stream is not None:
+                self.assertEqual(len(stream.traces), 3)
+                for trace in stream.traces:
+                    self.assertEqual(trace.get_id(), 'AA.1111..GP1')
+                    self.assertEqual(
+                        (trace.stats.starttime, trace.stats.endtime),
+                        trace_times[count_trace])
+                    self.assertEqual(trace.stats.sampling_rate, 1000)
+                    self.assertEqual(trace.stats.npts, 30000)
+                    count_trace += 1
+                count_stream += 1
+            count_time_cut += 1
+
+        self.assertEqual(count_stream, 1)
 
 
 if __name__ == "__main__":

--- a/ph5/test_data/segd/Das_t_1X1111.0.0_SRM0.kef
+++ b/ph5/test_data/segd/Das_t_1X1111.0.0_SRM0.kef
@@ -1,0 +1,183 @@
+#
+#	Mon Nov 16 22:35:28 2020	ph5 version: 4.1.2
+#
+#   Table row 1
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0001
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=1
+	event_number_i=1
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=1
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:00:00 2019
+	time/epoch_l=1562256000
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 2
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0004
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=2
+	event_number_i=1
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=2
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:00:00 2019
+	time/epoch_l=1562256000
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 3
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0007
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=3
+	event_number_i=1
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=0
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:00:00 2019
+	time/epoch_l=1562256000
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 4
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0002
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=1
+	event_number_i=2
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=1
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:00:30 2019
+	time/epoch_l=1562256030
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 5
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0005
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=2
+	event_number_i=2
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=2
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:00:30 2019
+	time/epoch_l=1562256030
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 6
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0008
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=3
+	event_number_i=2
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=0
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:00:30 2019
+	time/epoch_l=1562256030
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 7
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0003
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=1
+	event_number_i=3
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=1
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:01:00 2019
+	time/epoch_l=1562256060
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 8
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0006
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=2
+	event_number_i=3
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=2
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:01:00 2019
+	time/epoch_l=1562256060
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0
+#   Table row 9
+/Experiment_g/Receivers_g/Das_g_1X1111/Das_t
+	array_name_SOH_a=
+	array_name_data_a=Data_a_0009
+	array_name_event_a=
+	array_name_log_a=
+	channel_number_i=3
+	event_number_i=3
+	raw_file_name_s=1111.0.0.fcnt
+	receiver_table_n_i=0
+	response_table_n_i=0
+	sample_count_i=30000
+	sample_rate_i=1000
+	sample_rate_multiplier_i=0
+	stream_number_i=1
+	time/ascii_s=Thu Jul  4 16:01:00 2019
+	time/epoch_l=1562256060
+	time/micro_seconds_i=329999
+	time/type_s=BOTH
+	time_table_n_i=0


### PR DESCRIPTION
### What does this PR do?
This is the first solution to fix the issue #386.
Currently in experiment.py, ReceiversGroup.read_das() change value 0 of sample_rate_multiplier (srm) to 1. This PR will change PH5.query_das_t() in ph5api to behave the same way.
 
### Problem with the solution
PH5 data remain unchanged and still have srm=0 those the querying function consider it has no problem at all.
=> will develop a different solution for this issue.
