### PR TITLE
Fixed typo in segd_h_smartsolo.py causing minute and second fields in…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ ph5.utilities.pformagui
 ph5.utilities.segdtoph5
  * Fixed bug causing pforma to finish correctly on node (issue #233)
  * fixed bug in utmzone processing
+ * Fixed bug in smartsolo reading causing incorrect time conversions from BCD
 ph5.core.experiment
  * fixed bug found by Natalie (issue #231)
  * fix fast offset_table reading (issue #280)

--- a/ph5/core/segd_h_smartsolo.py
+++ b/ph5/core/segd_h_smartsolo.py
@@ -157,8 +157,8 @@ class General_header_block (Header_block):
                 # doc: 1 bytes for HHMMSS
                 # but Byte No.=14-16 which actually 3 bytes
                 ("hour_of_day_utc", 8, 'bcd'),
-                ("minute_of_hour_utc", 8, 'bdc'),
-                ("second_of_minute_utc", 8, 'bdc'),
+                ("minute_of_hour_utc", 8, 'bcd'),
+                ("second_of_minute_utc", 8, 'bcd'),
                 ("manufactures_code", 8, 'bcd'),                    # 0x61
                 ("manufactures_sn", 2*8, 'bcd'),                    # 0
                 ("bytes_per_scan", 3*8, 'bcd'),


### PR DESCRIPTION
### What does this PR do?

This PR fixes an error with segdtoph5 for smartsolo data, by correcting two typos in segd_h_reader.py, which resulted in the minutes and seconds fields being interpreted as raw binary data instead of binary-coded decimal, when read from the general header.

### Relevant Issues?

On Monday a report was made that segdtoph5 was failing for some smartsolo data, due to the minute and second fields overflowing the valid ranges for `ph5.core.timedoy.TimeDOY`, resulting in an exception:

```
(ph5) ph5@ph5-2:/external/ph5/Working/HC_Seismic/test-archive4$ cp bu-master master.ph5
(ph5) ph5@ph5-2:/external/ph5/Working/HC_Seismic/test-archive4$ vi ../segd-5478-list

(ph5) ph5@ph5-2:/external/ph5/Working/HC_Seismic/test-archive4$ segdtoph5 -n master.ph5 -f ../segd-5478-list -M 1
[2021-07-09 16:48:53,453] - ph5.utilities.segd2ph5 - INFO: segd2ph5 2021.159
[2021-07-09 16:48:53,453] - ph5.utilities.segd2ph5 - INFO: ['/home/ph5/anaconda3/envs/ph5/bin/segdtoph5', '-n', 'master.ph5', '-f', '../segd-5478-list', '-M', '1']
Traceback (most recent call last):
  File "/home/ph5/anaconda3/envs/ph5/bin/segdtoph5", line 11, in <module>
    load_entry_point('ph5', 'console_scripts', 'segdtoph5')()
  File "/home/ph5/PH5/ph5/utilities/segd2ph5.py", line 1368, in main
    prof()
/external/ph5/Working/HC_Seismic/HC_1station/MoreData/453005478.6.2020.10.03.16.23.45.000.E.segd
  File "/home/ph5/PH5/ph5/utilities/segd2ph5.py", line 1228, in prof
    SD.process_general_headers()
  File "/home/ph5/PH5/ph5/core/segdreader_smartsolo.py", line 181, in process_general_headers
    self.reel_headers.general_header_blocks[0])
  File "/home/ph5/PH5/ph5/core/segdreader_smartsolo.py", line 137, in get_deploy_epoch
    second=ghb.second_of_minute_utc)
  File "/home/ph5/PH5/ph5/core/timedoy.py", line 109, in __init__
    "Value for second, {0}, out of range!".format(second))
ph5.core.timedoy.TimeError: Value for second, 69, out of range!
Closing remaining open files:./master.ph5...done
```
A corresponding issue was not created on github.

### Checklist
- [ x ] This PR is not directly related to an existing issue (which has no PR yet).
- [ x ] All tests pass.
- [ x ] Any new or changed features have are documented.
- [ x ] Changes have been added to `CHANGELOG.txt` .
- [ x ] First time contributors have added your name to `CONTRIBUTORS.txt` .
