### PR TITLE
Fix sort_kef_gen error due to empty table

### DIFF
--- a/ph5/core/experiment.py
+++ b/ph5/core/experiment.py
@@ -39,6 +39,8 @@ def check_srm_valid(rows, keys, tablename, ignore_srm=False):
     :param tablename: name of the table (string)
     :param ignore_srm: flag to ignore checking srm when it is True (boolean)
     """
+    if keys is None:
+        return rows, keys, tablename, ignore_srm
     if ignore_srm:
         return
     if 'sample_rate_multiplier_i' not in keys:


### PR DESCRIPTION
### What does this PR do?
Make check_srm() not process if table is empty.

### Relevant Issues?
It's appear that this branch is also dealing with the issue described #480

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
