### PR TITLE
Optimize geo_kef_gen

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -123,7 +123,8 @@ ph5.core.ph5api
  * skip ph5api cut traces that return no data. logic previously embedded in code but line 1302 is duplicated onto 1287 to prevent error from being thrown
  * fix ph5api cut sometimes returns too many samples (issue #298)
  * fix for get_availability returning incomplete results
-  * fix query_das_t to throw error is sample_rate_multiplier_is=0 or is missing
+ * fix query_das_t to throw error is sample_rate_multiplier_is=0 or is missing
+ * Remove the call to read_array_t() channels() to optimize geo_kef_gen
 ph5.entry_points
  * creates a dictionary, keys are names of scripts,
       values are (1) simple description,

--- a/ph5/core/ph5api.py
+++ b/ph5/core/ph5api.py
@@ -270,7 +270,7 @@ class PH5(experiment.ExperimentGroup):
               returns a list of channels for this station
         '''
         try:
-            self.read_array_t(array)
+            # self.read_array_t(array)
             chans = sorted(self.Array_t[array]['byid'][station].keys())
             return chans
         except Exception:

--- a/ph5/core/ph5api.py
+++ b/ph5/core/ph5api.py
@@ -9,13 +9,16 @@ import logging
 import os
 import time
 import re
-import numpy as np
 import math
+
+import numpy as np
 from pyproj import Geod
-from ph5.core import columns, experiment, timedoy
 from tables.exceptions import NoSuchNodeError
 
-PROG_VERSION = '2021.47'
+from ph5.core import columns, experiment, timedoy
+
+
+PROG_VERSION = '2021.322'
 
 LOGGER = logging.getLogger(__name__)
 PH5VERSION = columns.PH5VERSION

--- a/ph5/core/tests/test_ph5api.py
+++ b/ph5/core/tests/test_ph5api.py
@@ -1115,6 +1115,8 @@ class TestPH5API(LogTestCase):
                          times[0])
 
     def test_channels(self):
+        # add read_array_t() bc commented it out in channels()
+        self.ph5API_object.read_array_t('Array_t_001')
         # should give 3 channels
         chans = self.ph5API_object.channels(
             'Array_t_001',
@@ -1122,6 +1124,7 @@ class TestPH5API(LogTestCase):
         self.assertEqual(3, len(chans))
         self.assertEqual([1, 2, 3], chans)
 
+        self.ph5API_object.read_array_t('Array_t_004')
         # should give 1 channels
         chans = self.ph5API_object.channels(
             'Array_t_004',


### PR DESCRIPTION
### What does this PR do?
Solving issue #488 in which geo_kef_gen takes too long to complete.

### Issue found:
Repeatedly call read_array_t() in 3rd nested loop though it has been called in the outside loop.

### Solution
Remove the call to read_array_t() in PH5.channels()

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
