### PR TITLE
ph5validate: handle case same time range of das has been repeatly ent…

### DIFF
--- a/ph5/utilities/ph5validate.py
+++ b/ph5/utilities/ph5validate.py
@@ -487,6 +487,20 @@ class PH5Validate(object):
             # delete all duplicates except for the last one
             del das_time_list[dups[0]:dups[-1]]
 
+        # check for duplicates on different stations:
+        dups = [x for x in das_time_list
+                if x[0] == item[0] and x[1] == item[1] and x[2] != item[2]]
+        dup_stations = [x[2] for x in dups]
+        if len(dups) > 0:
+            error.append("Das %s chan %s spr %s has been repeatly entered for "
+                         "time range [%s, %s] on stations: %s" %
+                         (das_serial, channel_id, sample_rate,
+                          deploy_time, pickup_time,
+                          ', '.join([station_id] + dup_stations)))
+            # delete all duplicates stations for das
+            for x in dups:
+                das_time_list.remove(x)
+
         index = das_time_list.index((deploy_time, pickup_time, station_id))
 
         overlaps = []

--- a/ph5/utilities/tests/test_ph5validate.py
+++ b/ph5/utilities/tests/test_ph5validate.py
@@ -432,6 +432,26 @@ class TestPh5Validate_conflict_time(TempDirTestCase, LogTestCase):
                       "You may need to reload the raw data for this station.",
                       errors)
 
+    def test_check_station_completeness_duplicate_das_for_diff_stations(self):
+        self.ph5validate.das_time = {
+            ('12183', 1, 500):
+            {'time_windows': [(1550849950, 1550850034, '9001'),
+                              (1550849950, 1550850034, '9002')],
+             'min_deploy_time': [1550849950],
+             }
+        }
+
+        self.ph5validate.read_arrays('Array_t_009')
+        arraybyid = self.ph5validate.ph5.Array_t['Array_t_009']['byid']
+        station = arraybyid.get('9001')[1][0]
+        ret = self.ph5validate.check_station_completeness(station)
+        errors = ret[2]
+        self.assertEqual(
+            errors,
+            ['No Response table found. Have you run resp_load yet?',
+             'Das 12183 chan 1 spr 500 has been repeatly entered for '
+             'time range [1550849950, 1550850034] on stations: 9001, 9002'])
+
 
 class TestPh5Validate_currPH5(TempDirTestCase, LogTestCase):
     def setUp(self):


### PR DESCRIPTION
### What does this PR do?
Fix bug #508 according to Stephen's test case. In this test case the same time range from the same das has been entered to two different stations.
I have implemented code for ph5validate to detect that case and report to ph5validate.log. However, I don't know if it handles the case that Emily listed in 508 or not because the error `List index out of range` might come from different situations.

### Relevant Issues?
#508

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .