### PR TITLE
using maping filename and array, station in pforma to sort SmartSolo's das table

### DIFF
--- a/ph5/core/pmonitor.py
+++ b/ph5/core/pmonitor.py
@@ -17,7 +17,6 @@ import os
 import re
 from threading import Thread
 from Queue import Queue, Empty
-from ph5.utilities.pforma_io import guess_instrument_type
 from ph5.utilities import watchit
 import time
 
@@ -405,10 +404,8 @@ class Monitor (QtWidgets.QWidget):
         elif fileDoneRE.match(line):
             self.log.append("Time processing {0} seconds.".format(
                 int(time.time() - Monitor.NOW)))
-            dtype, das = guess_instrument_type(
-                os.path.basename(self.current_file), self.current_file.strip(),
-                self.main_window
-            )
+            dtype = self.fio.file_das_type[self.current_file]['type']
+            das = self.fio.file_das_type[self.current_file]['das']
             # Update the list of successfully processed file
             if dtype != 'unknown':
                 if das not in self.processedFiles:
@@ -434,7 +431,7 @@ class Monitor (QtWidgets.QWidget):
             #
             Monitor.NOW = time.time()
             mo = fileStartRE.match(line)
-            self.current_file = mo.groups()[0]
+            self.current_file = mo.groups()[0].strip()
             # We really only need to do this once
             if self.monPercent == 0.01:
                 self.fp.processingStyle()

--- a/ph5/entry_points.py
+++ b/ph5/entry_points.py
@@ -244,7 +244,7 @@ class CommandList():
                            'SEG-D file names that expose information '
                            'about the contents of the file.',
                            type=EntryPointTypes.EDITING),
-                EntryPoint('mapheader',
+                EntryPoint('map_header',
                            'ph5.utilities.map_header:main',
                            'A command line utility for SmartSolo SEG-D '
                            'to create mapping between filepaths and their '

--- a/ph5/entry_points.py
+++ b/ph5/entry_points.py
@@ -244,6 +244,12 @@ class CommandList():
                            'SEG-D file names that expose information '
                            'about the contents of the file.',
                            type=EntryPointTypes.EDITING),
+                EntryPoint('mapheader',
+                           'ph5.utilities.map_header:main',
+                           'A command line utility for SmartSolo SEG-D '
+                           'to create mapping between filepaths and their '
+                           'array, station.',
+                           type=EntryPointTypes.EDITING),
                 EntryPoint('set_deploy_pickup_times',
                            'ph5.utilities.set_deploy_pickup_times:main',
                            'Set deploy and pickup times in '

--- a/ph5/utilities/map_header.py
+++ b/ph5/utilities/map_header.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env pnpython4
+#
+# create map of file paths and (array, station) for SmartSolo files
+#
+# Input: List of SmartSolo files to create map in a file (one per line)
+#
+# Usage: mapheader list_of_files_to_create_map
+#
+# Lan Dam, November 2023
+#
+import argparse
+import sys
+import os
+import logging
+from ph5.core import segdreader_smartsolo
+from ph5 import LOGGING_FORMAT
+
+PROG_VERSION = '2023.318'
+LOGGER = logging.getLogger(__name__)
+
+
+def get_args():
+    """
+    Get inputs
+    """
+    global ARGS
+
+    parser = argparse.ArgumentParser()
+
+    parser.description = ("A command line utility for SmartSolo SEG-D "
+                          "to create mapping between filepaths and their "
+                          "array, station. v{0}"
+                          .format(PROG_VERSION))
+
+    parser.add_argument("-f", "--listfile", dest="sslistfile",
+                        help="File that contents the list of SmartSolo SEG-D "
+                             "files to create map.",
+                        required=True)
+
+    ARGS = parser.parse_args()
+
+    if not os.path.exists(ARGS.sslistfile):
+        LOGGER.error("Can not read {0}!".format(ARGS.sslistfile))
+        sys.exit()
+    set_logger()
+
+
+def set_logger():
+    if LOGGER.handlers != []:
+        LOGGER.removeHandler(LOGGER.handlers[0])
+
+    # Write log to file
+    ch = logging.FileHandler("mapheader.log")
+    ch.setLevel(logging.INFO)
+    # Add formatter
+    formatter = logging.Formatter(LOGGING_FORMAT)
+    ch.setFormatter(formatter)
+    LOGGER.addHandler(ch)
+
+
+def create_mapping_line_for_smartsolo(path2file):
+    """
+    Read array_id and station_id from header of the given file to give back das
+    name for the file
+
+    :param path2file: absolute path to the file to get the info
+    :return mapping line: in format: path2file:<array_id>X<station_id>
+    """
+    try:
+        sd = segdreader_smartsolo.Reader(infile=path2file)
+    except BaseException:
+        LOGGER.error(
+            "Failed to properly read {0}.".format(path2file))
+        sys.exit()
+    sd.process_general_headers()
+    sd.process_channel_set_descriptors()
+    sd.process_extended_headers()
+    sd.process_external_headers()
+    sd.process_trace_headers()
+    arg = {'file': path2file}
+    arg['array_id'] = sd.trace_headers.line_number
+    arg['station_id'] = sd.trace_headers.receiver_point
+    return "%(file)s:%(array_id)sX%(station_id)s\n" % arg
+
+
+def main():
+    get_args()
+
+    with open(ARGS.sslistfile) as list_file:
+        with open("smartsolo_map", 'w') as map_file:
+            while True:
+                line = list_file.readline()
+                if not line:
+                    break
+                asbpath = line.strip()
+                if not os.path.exists(asbpath):
+                    LOGGER.warning("Can't find: {0}".format(asbpath))
+                    continue
+                map_line = create_mapping_line_for_smartsolo(asbpath)
+                map_file.write(map_line)
+
+
+if __name__ == '__main__':
+    main()

--- a/ph5/utilities/map_header.py
+++ b/ph5/utilities/map_header.py
@@ -29,8 +29,8 @@ def get_args():
     parser = argparse.ArgumentParser()
 
     parser.description = ("A command line utility for SmartSolo SEG-D "
-                          "to create mapping between filepaths and their "
-                          "array, station. v{0}"
+                          "to create `smartsolo_map` between filepaths and "
+                          "their array, station. v{0}"
                           .format(PROG_VERSION))
 
     group = parser.add_mutually_exclusive_group(required=True)

--- a/ph5/utilities/pforma_io.py
+++ b/ph5/utilities/pforma_io.py
@@ -57,6 +57,7 @@ class FormaIO():
         self.infile = infile  # Input file (list of raw files)
         self.infh = None  # File handle for infile
         self.raw_files = {}  # Raw files organized by type
+        self.file_das_type = {}  # Das, type by file paths
         self.total_raw = 0.0  # Total size of raw
         self.number_raw = 0
         self.home = outdir  # Where the processing of the ph5 files happens
@@ -441,16 +442,23 @@ class FormaIO():
             # Skip empty line
             if not line:
                 continue
+            line_parts = line.split(':')
+            file_abs_path = line_parts[0]
             # Skip files that do not exist
-            if not os.path.exists(line):
+            if not os.path.exists(file_abs_path):
                 LOGGER.warning(
-                    "{0} not found. Skipping.".format(line))
+                    "{0} not found. Skipping.".format(file_abs_path))
                 continue
             n += 1
+
             # Try to guess data logger type and serial number based on file
             # name
-            raw_file = os.path.basename(line)
-            tp, das = guess_instrument_type(raw_file, line, self.main_window)
+            raw_file = os.path.basename(file_abs_path)
+            if len(line_parts) > 1:
+                tp, das = 'nodal', line_parts[1]
+            else:
+                tp, das = guess_instrument_type(raw_file, file_abs_path,
+                                                self.main_window)
             if das == 'lllsss':
                 raise FormaIOError(
                     errno=4,
@@ -471,18 +479,18 @@ class FormaIO():
             # Type of data logger
             file_info['type'] = tp
             # Full path to raw file
-            file_info['path'] = line
+            file_info['path'] = file_abs_path
             # Size of raw file in bytes
-            file_info['size'] = os.stat(line).st_size
+            file_info['size'] = os.stat(file_abs_path).st_size
             # Time file was modified
-            file_info['mtime'] = os.stat(line).st_mtime
+            file_info['mtime'] = os.stat(file_abs_path).st_mtime
             # file_info['adler'] = check_sum (line)
             # Which family of ph5 files does this belong to. See self.nmini
             file_info['mini'] = None
             # Total of raw files so far in bytes
             self.total_raw += file_info['size']
             self.raw_files[das].append(file_info)
-
+            self.file_das_type[file_abs_path] = {'das': das, 'type': tp}
         self.average_raw = int(self.total_raw / n)
         self.number_raw = n
         self.infh.close()

--- a/ph5/utilities/pforma_io.py
+++ b/ph5/utilities/pforma_io.py
@@ -830,7 +830,7 @@ def get_smartsolo_array_station(path2file):
         sd = segdreader_smartsolo.Reader(infile=path2file)
     except BaseException:
         LOGGER.error(
-            "Failed to properly read {0}.".format(filename))
+            "Failed to properly read {0}.".format(path2file))
         sys.exit()
     sd.process_general_headers()
     sd.process_channel_set_descriptors()

--- a/ph5/utilities/pformagui.py
+++ b/ph5/utilities/pformagui.py
@@ -35,9 +35,12 @@ class GetInputs(QtWidgets.QWidget):
         self.runButton = QtWidgets.QPushButton("Run")
         # Select master list of raw files
         self.lstButton = self.createButton("Browse...", self.getList)
-        self.lstButton.setStatusTip("Browse for raw lst file.")
+        self.lstButton.setStatusTip(
+            "Browse for raw list file. "
+            "For SmartSolo, map file created by map_header can be used to "
+            "reduce reading file headers when building ph5. ")
         self.lstCombo = self.createComboBox()
-        lstText = QtWidgets.QLabel("RAW list file:")
+        lstText = QtWidgets.QLabel("MAP/RAW list file:")
         # Select processing directory
         lstLayout = QtWidgets.QHBoxLayout()
         lstLayout.addStretch(False)


### PR DESCRIPTION
### What does this PR do?
+ Create new tool `map_header` to create a map between file paths and their array, station from list file or directory of files
+ Modify pforma to read this map file to add file into ph5 in the correct order
+ Using file_das_type dictionary to get das and data type for current processed file instead of recalling  guess_instrument_type() again. This improve the performance of processing SmartSolo because guess_instrument_type() read SmartSolo's header for array and station information. (For this solution and the previous solution of SmartSolo as well.

**Notice**: to run `map_header`, users need to run the following command in ph5 conda environment: `pip install -e .`

To add SmartSolo to PH5 using SmartSolo you can do the following methods:
+ Using `pforma` with the SmartSolo list file which is the existing solution from #513 
+ Using `map_header` to create `smartsolo_map`. Then use `pforma` with this `smartsolo_map` file. This way the tasks of reading file headers won't be included in `pforma`

There are two option to run `map_header`:
```
 map_header -f smartsolo_list_file
```
Or
```
map_header -d smartsolo_directory
```

The latter can reduce the step of creating smartsolo_list_file but won't work if SmartSolo files are located in more than one folder.

### Relevant Issues?
#502 

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
