### PR TITLE
fix crashing on ph5toevt for event table with a numeric description s

### DIFF
--- a/ph5/core/segyfactory.py
+++ b/ph5/core/segyfactory.py
@@ -667,9 +667,10 @@ class Ssegy:
             if 0 <= desc_int <= 65535:
                 ext['empty3'] = desc_int
             else:
-                LOGGER.warning("event_t[description_s] '%s' is ignored "
-                               "because it doesn't satisfy the limit range "
-                               "[0, 65535]" % desc_int)
+                LOGGER.warning(
+                    "Event_t's description_s, %s, not added to segy header: "
+                    "Descriptions must be numeric values in range [0,65535] "
+                    "to be added to header." % desc_int)
         except BaseException:
             pass
 

--- a/ph5/core/segyfactory.py
+++ b/ph5/core/segyfactory.py
@@ -66,6 +66,7 @@ class SEGYError(Exception):
 
     def __init__(self, *args, **kwargs):
         self.args = (args, kwargs)
+        self.message = args[0]
 
 
 class Ssegy:

--- a/ph5/core/segyfactory.py
+++ b/ph5/core/segyfactory.py
@@ -663,7 +663,13 @@ class Ssegy:
 
         # 16 free bits
         try:
-            ext['empty3'] = int(self.event_t['description_s'])
+            desc_int = int(self.event_t['description_s'])
+            if 0 <= desc_int <= 65535:
+                ext['empty3'] = desc_int
+            else:
+                LOGGER.warning("event_t[description_s] '%s' is ignored "
+                               "because it doesn't satisfy the limit range "
+                               "[0, 65535]" % desc_int)
         except BaseException:
             pass
 


### PR DESCRIPTION
### What does this PR do?
+ Fix bug not printing out error message for `SEGYError`
+ Check condition of event_t['description_s'] to add to SEGY only when it is satisfied and to give warning when it isn't

### Relevant Issues?
#523 

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
