### PR TITLE
disable pforma for reading rt130 or seg2 data files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -108,6 +108,7 @@ ph5.utilities.pforma_io
  * add seg2 to pforma
  * fix bug that duplicate index_t and array_t when copy tables from A/master.ph5 to Sigma/master.ph5
  * make pforma read header info for station id and array id when reading SmartSolo
+ * disable reading seg2 and rt130 in pforma
 ph5.utilities.125atoph5
  * fix pforma support after LOGGER change
 ph5.utilities.130toph5

--- a/ph5/utilities/pforma_io.py
+++ b/ph5/utilities/pforma_io.py
@@ -469,6 +469,16 @@ class FormaIO():
                                    msg=("File in {1} does not have standard "
                                         "name: {0}").format(
                                        raw_file, self.infile))
+            if tp == 'rt-130':
+                raise FormaIOError(errno=5,
+                                   msg=("{0}: RT130 data detected, exit and "
+                                        "add data to PH5 with 130toph5."
+                                        ).format(raw_file))
+            if tp == 'seg2':
+                raise FormaIOError(errno=5,
+                                   msg=("{0}: SEG2 data detected, exit and "
+                                        "add data to PH5 with seg2toph5."
+                                        ).format(raw_file))
 
             # Save info about each raw file keyed by serial number in
             # self.raw_files

--- a/ph5/utilities/pforma_io.py
+++ b/ph5/utilities/pforma_io.py
@@ -16,7 +16,7 @@ import re
 
 from ph5.core import segdreader_smartsolo
 
-PROG_VERSION = '2023.12'
+PROG_VERSION = '2024.249'
 LOGGER = logging.getLogger(__name__)
 
 HOME = os.environ['HOME']

--- a/ph5/utilities/tests/test_pforma_io.py
+++ b/ph5/utilities/tests/test_pforma_io.py
@@ -104,5 +104,39 @@ class TestPforma(LogTestCase, TempDirTestCase):
         self.assertEqual(ret[1], expected_station_id)
 
 
+class TestPformaIONotRead(LogTestCase, TempDirTestCase):
+    def test_rt130(self):
+        rt130_dir = os.path.join(
+            self.home, "ph5/test_data/rt130/2016139.9EEF.ZIP")
+        with open('rt130_list', 'w') as list_file:
+            list_file.write(rt130_dir)
+        list_file_path = os.path.join(self.tmpdir, 'rt130_list')
+        fio = pforma_io.FormaIO(infile=list_file_path, outdir=self.tmpdir)
+        fio.open()
+        with self.assertRaises(pforma_io.FormaIOError) as contxt:
+            fio.read()
+        self.assertEqual(
+            contxt.exception.message,
+            '2016139.9EEF.ZIP: RT130 data detected, '
+            'exit and add data to PH5 with 130toph5.'
+        )
+
+    def test_seg2(self):
+        seg2_dir = os.path.join(
+            self.home, "ph5/test_data/seg2/15001.dat")
+        with open('seg2_list', 'w') as list_file:
+            list_file.write(seg2_dir)
+        list_file_path = os.path.join(self.tmpdir, 'seg2_list')
+        fio = pforma_io.FormaIO(infile=list_file_path, outdir=self.tmpdir)
+        fio.open()
+        with self.assertRaises(pforma_io.FormaIOError) as contxt:
+            fio.read()
+        self.assertEqual(
+            contxt.exception.message,
+            '15001.dat: SEG2 data detected, '
+            'exit and add data to PH5 with seg2toph5.'
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### What does this PR do?
Give Error message when pforma read rt130 or seg2 data

### Relevant Issues?
#530

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests pass.
- [ ] Any new or changed features have are documented.
- [X] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
