### PR TITLE
Use a safer number of families to avoid segmentation faults

### DIFF
--- a/ph5/utilities/pformagui.py
+++ b/ph5/utilities/pformagui.py
@@ -504,6 +504,21 @@ def get_len(f):
     return num_lines
 
 
+def calc_total_families():
+    """
+    Use half of physical cores to reduce memory pressure / I/O contention to
+    avoid segmentation faults.
+    """
+    phys = cpu_count(logical=False) or cpu_count(logical=True)
+    logi = cpu_count(logical=True)
+
+    if phys and phys > 0:
+        total_families = max(1, phys // 2)
+    else:
+        total_families = max(1, logi // 2)
+    return total_families
+
+
 def init_fio(f, d, utm=None, combine=None, main_window=None):
     '''
         Initialize parallel processing
@@ -520,11 +535,8 @@ def init_fio(f, d, utm=None, combine=None, main_window=None):
         fio.set_utm(utm)
     if combine:
         fio.set_combine(combine)
-    if cpu_count(logical=False) > 3:
-        fio.set_nmini(cpu_count(logical=True) + 1)
-    else:
-        fio.set_nmini(cpu_count(logical=True))
 
+    fio.set_nmini(calc_total_families())
     fio.initialize_ph5()
 
     try:


### PR DESCRIPTION
### What does this PR do?
The segmentation faults in PH5 file might come from running out of resources in server since it is inconsistent.
This PR try to use a safer number of families to avoid that.
In the current master branch, number of family is logical + 1  which is in higher peak memory and more likely to makes segfaults. (in ph51 number of family  is 49)
In this branch, number of family has been changed to half of physical cores; fallback to half of logical. (in ph51 number of family is 12)
For ph51 server the current
### Relevant Issues?
#554 

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests pass.
- [ ] Any new or changed features have are documented.
- [ ] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
