### PR TITLE
for rt125 (texan) das, change the error for no data found for das to warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
         python --version
         conda create -q -n ph5 python=${{ matrix.python-version }}
         conda config --add channels conda-forge
-        conda config --set restore_free_channel true
         conda env update --name ph5 --file environment.yml
         conda install flake8
     

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 Master:
 ph5
+ * Removed the key in .github/workflows/tests.yml to fix CondaError: 'restore_free_channel': unknown parameter
  * Add flag --force to not used commands mstoph5, metadatatoph5, segytoph5 and request that flag to run the commands.
  * Make Ph5 availability accout for metadata content.
  * Split avaiabiity information on metadata epochs
@@ -75,6 +76,7 @@ ph5.clients.ph5tostationxml
  * In case of other bugs, not create stationxml. Use flag --stationxml_on_error to create stationxml if bug present in the data
  * Multiprocessing has been removed because when checking subfolders of the given path, multiprocessing make the logging messages show up randomly. Using 'for loop' instead help users recognize which one the messages are for. That way ph5tostationxml can inform when never stationxml has or has not been created for a ph5 data.
 ph5.clients.ph5availability
+ * For rt125 (texan) das, change the error for no data found for das to warning
  * New client for returning timeseries availability information
  * Consider array time instead of das time only
 ph5.utilities.ph5validate

--- a/ph5/utilities/ph5validate.py
+++ b/ph5/utilities/ph5validate.py
@@ -18,8 +18,16 @@ import operator
 from ph5.core import ph5api, experiment
 from ph5.utilities import validation
 
-PROG_VERSION = "2022.066"
+PROG_VERSION = "2026.055"
 LOGGER = logging.getLogger(__name__)
+
+
+def check_rt125_format(serial):
+    """
+    Return True For rt125 das serial number with format
+      [1-9][1-9][1-9][1-9][1-9]
+    """
+    return bool(re.match(r"^[1-9]{5}$", serial))
 
 
 class ValidationBlock(object):
@@ -464,10 +472,14 @@ class PH5Validate(object):
         sample_rate = station['sample_rate_i']
         nodata_err = None
         if das_serial not in self.ph5.Das_t:
-            error.append("No data found for das serial number {0}. "
+            alert_msg = ("No data found for das serial number {0}. "
                          "You may need to reload the raw "
                          "data for this station."
                          .format(str(das_serial)))
+            if check_rt125_format(das_serial):
+                warning.append(alert_msg)
+            else:
+                error.append(alert_msg)
         dt = self.das_time[(das_serial, channel_id, sample_rate)]
         # add bound_errors if applicable
         if deploy_time == dt['min_deploy_time'][0]:
@@ -545,10 +557,14 @@ class PH5Validate(object):
 
                 if true_start is None and nodata_err is None:
                     # check nodata_err to avoid duplicate error
-                    error.append(
+                    alert_msg = (
                         "No data found for das serial number {0} during this "
                         "station's time. You may need to reload the raw "
                         "data for this station.".format(str(das_serial)))
+                    if check_rt125_format(das_serial):
+                        warning.append(alert_msg)
+                    else:
+                        error.append(alert_msg)
                 else:
                     # don't check deploy time because the time sent to
                     # get_extent() is limited from deploy time

--- a/ph5/utilities/ph5validate.py
+++ b/ph5/utilities/ph5validate.py
@@ -25,9 +25,9 @@ LOGGER = logging.getLogger(__name__)
 def check_rt125_format(serial):
     """
     Return True For rt125 das serial number with format
-      [1-9][1-9][1-9][1-9][1-9]
+      [1-9][0-9][0-9][0-9][0-9]
     """
-    return bool(re.match(r"^[1-9]{5}$", serial))
+    return bool(re.match(r"^[1-9][0-9]{4}$", serial))
 
 
 class ValidationBlock(object):

--- a/ph5/utilities/tests/test_ph5validate.py
+++ b/ph5/utilities/tests/test_ph5validate.py
@@ -60,14 +60,11 @@ class TestPH5Validate_response_info(LogTestCase, TempDirTestCase):
                 self.assertEqual(r.heading,
                                  "-=-=-=-=-=-=-=-=-\n"
                                  "Station 9001 Channel 1\n"
-                                 "4 error, 1 warning, 0 info\n"
+                                 "3 error, 2 warning, 0 info\n"
                                  "-=-=-=-=-=-=-=-=-\n"
                                  )
                 # this error causes by changing samplerate
                 errors = [
-                    "No data found for das serial number 12183 during "
-                    "this station's time. You may need to reload the "
-                    "raw data for this station.",
                     'Response_t[4]:No response data loaded for gs11.',
                     "Response_t[4]:response_file_das_a 'rt125a_500_1_32' is "
                     "inconsistent with Array_t_009:sr=100. Please check with "
@@ -79,7 +76,11 @@ class TestPH5Validate_response_info(LogTestCase, TempDirTestCase):
                     set(errors))
                 self.assertEqual(
                     r.warning,
-                    ['No station description found.'])
+                    ['No station description found.',
+                     "No data found for das serial number 12183 during "
+                     "this station's time. You may need to reload the "
+                     "raw data for this station."
+                     ])
             if 'Station 0407 Channel -2' in r.heading:
                 self.assertEqual(r.heading,
                                  "-=-=-=-=-=-=-=-=-\n"
@@ -416,11 +417,11 @@ class TestPh5Validate_conflict_time(TempDirTestCase, LogTestCase):
         station['pickup_time/epoch_l'] = 1550850191
         DT['time_windows'][5] = (1550850190, 1550850191, '9003')
         ret = self.ph5validate.check_station_completeness(station)
-        errors = ret[2]
+        warnings = ret[1]
         self.assertIn("No data found for das serial number 12183 during this "
                       "station's time. You may need to reload the raw data "
                       "for this station.",
-                      errors)
+                      warnings)
         # check no data found errors
         station = arraybyid.get('9002')[1][0]
         station['das/serial_number_s'] = '1218'
@@ -431,6 +432,30 @@ class TestPh5Validate_conflict_time(TempDirTestCase, LogTestCase):
         self.assertIn("No data found for das serial number 1218. "
                       "You may need to reload the raw data for this station.",
                       errors)
+
+        # Error for non-texan with no data
+        self.ph5validate.das_time = {
+            ('2X3', 1, 500):
+                {'time_windows': [(1550850125, 1550850187, '9003')],
+                 'min_deploy_time': [
+                     1550849950,
+                     'Data exists before deploy time: 7 seconds.'],
+                 }
+        }
+        station = arraybyid.get('9003')[1][0]
+        station['das/serial_number_s'] = '2X3'
+        station['deploy_time/epoch_l'] = 1550850190
+        station['pickup_time/epoch_l'] = 1550850191
+        DT = self.ph5validate.das_time[('2X3', 1, 500)]
+        DT['time_windows'][0] = (1550850190, 1550850191, '9003')
+        ret = self.ph5validate.check_station_completeness(station)
+        no_data_msg = ("No data found for das serial number 2X3 during this "
+                       "station's time. You may need to reload the raw data "
+                       "for this station.")
+        warnings = ret[1]
+        errors = ret[2]
+        self.assertNotIn(no_data_msg, warnings)
+        self.assertIn(no_data_msg, errors)
 
     def test_check_station_completeness_duplicate_das_for_diff_stations(self):
         self.ph5validate.das_time = {


### PR DESCRIPTION
### What does this PR do?
For rt125 (texan) das (with serial number format 1-9][0-9][0-9][0-9][0-9]), change the error for no data found for das to warning

### Relevant Issues?
Removed the key in .github/workflows/tests.yml to CondaError that prevent merging: 'restore_free_channel': unknown parameter

closes #552

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests pass.
- [X] Any new or changed features have are documented.
- [X] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
