### PR TITLE
change error for location/X/value_d=0 and location/Y/value_d=0 to warning

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -76,7 +76,6 @@ ph5.clients.ph5tostationxml
  * In case of other bugs, not create stationxml. Use flag --stationxml_on_error to create stationxml if bug present in the data
  * Multiprocessing has been removed because when checking subfolders of the given path, multiprocessing make the logging messages show up randomly. Using 'for loop' instead help users recognize which one the messages are for. That way ph5tostationxml can inform when never stationxml has or has not been created for a ph5 data.
 ph5.clients.ph5availability
- * For rt125 (texan) das, change the error for no data found for das to warning
  * New client for returning timeseries availability information
  * Consider array time instead of das time only
 ph5.utilities.ph5validate
@@ -215,6 +214,8 @@ v4.1.1:
  * Fix ph5toms not returning data
  * Fix bug that caused ph5toms to crash when passed an empty DAS_t after filtering
 -ph5.utilities.ph5_validate
+ * For rt125 (texan) das, change the error for no data found for das to warning
+ * Change error for location/X/value_d=0 and location/Y/value_d=0 to warning because they are valid coordinates
  * New functionality for checking stations
 -ph5.utilities.kef2kml
  * Fix bug reading kef

--- a/ph5/utilities/ph5validate.py
+++ b/ph5/utilities/ph5validate.py
@@ -787,7 +787,7 @@ class PH5Validate(object):
         # projection_s , ellipsoid_s , description_s
         # because they are not required and most of PIs do not fill them out
         if event['location/X/value_d'] == 0:
-            error.append("Event location/X/value_d "
+            warning.append("Event location/X/value_d "
                          "'longitude' seems to be 0. "
                          "Is this correct???")
         if event['location/X/units_s'] in [None, '']:
@@ -795,7 +795,7 @@ class PH5Validate(object):
                            "found.")
 
         if event['location/Y/value_d'] == 0:
-            error.append("Event location/Y/value_d "
+            warning.append("Event location/Y/value_d "
                          "'latitude' seems to be 0. "
                          "Is this correct???")
         if event['location/Y/units_s'] in [None, '']:

--- a/ph5/utilities/tests/test_ph5validate.py
+++ b/ph5/utilities/tests/test_ph5validate.py
@@ -678,5 +678,43 @@ class TestPH5Validate_das_t_order(LogTestCase, TempDirTestCase):
                       loglines)
 
 
+
+class Test_Location_value0(LogTestCase, TempDirTestCase):
+    def setUp(self):
+        super(Test_Location_value0, self).setUp()
+        ph5path = os.path.join(
+            self.home,
+            "ph5/test_data/ph5_ph5validate/location_value0")
+        self.ph5API_object = ph5api.PH5(path=ph5path, nickname='master.ph5')
+        self.ph5validate = ph5validate.PH5Validate(self.ph5API_object, ph5path)
+
+    def tearDown(self):
+        self.ph5API_object.close()
+        super(Test_Location_value0, self).tearDown()
+
+    def test_check_event_t_completeness(self):
+        with LogCapture() as log:
+            log.setLevel(logging.WARNING)
+            self.ph5API_object.read_event_t('Event_t_001')
+            event = self.ph5API_object.Event_t['Event_t_001']['byid']['4446']
+            inf, warn, err = self.ph5validate.check_event_t_completeness(event)
+            self.assertIn(
+                "Event location/X/value_d 'longitude' seems to be 0. "
+                "Is this correct???",
+                 warn)
+            self.assertIn(
+                "Event location/Y/value_d 'latitude' seems to be 0. "
+                "Is this correct???",
+                warn)
+            self.assertNotIn(
+                "Event location/X/value_d 'longitude' seems to be 0. "
+                "Is this correct???",
+                err)
+            self.assertNotIn(
+                "Event location/Y/value_d 'latitude' seems to be 0. "
+                "Is this correct???",
+                err)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### What does this PR do?
Change error for location/X/value_d=0 and location/Y/value_d=0 to warning because they are valid coordinates

### Relevant Issues?
closes #558

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [ ] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
