### PR TITLE
fix bug that not reset list of shots when the loop moves to the next shotline

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -195,6 +195,7 @@ ph5.clients.ph5torec
 -ph5.clients.ph5view
  * Better handling of experiments with missing tables
 -ph5.clients.ph5toexml
+ * Fix bug that not reset list of shots when looping to the next shotline
  * Remove new line from geocsv field_unit header line
 -ph5.utilities.kefedit
  * Fix bugs caused when loading PH5 experiment without offset tables

--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -337,9 +337,9 @@ class PH5toexml(object):
                           self.experiment_t[0]['longname_s'])
 
         shot_lines_ = []
-        shots = []
 
         for shot_line in shot_lines:
+            shots = []
             sl = Shotline(shot_line)
             event_t = self.ph5.Event_t[shot_line]['byid']
             if self.args.get('shotline') and \

--- a/ph5/clients/ph5toexml.py
+++ b/ph5/clients/ph5toexml.py
@@ -20,7 +20,7 @@ import types
 import logging
 from ph5.core import ph5api, ph5utils
 
-PROG_VERSION = '2018.268'
+PROG_VERSION = '2026.190'
 LOGGER = logging.getLogger(__name__)
 
 

--- a/ph5/clients/tests/test_ph5toexml.py
+++ b/ph5/clients/tests/test_ph5toexml.py
@@ -1,5 +1,4 @@
 '''
-<<<<<<< HEAD
 Tests for ph5toexml
 '''
 import unittest

--- a/ph5/clients/tests/test_ph5toexml.py
+++ b/ph5/clients/tests/test_ph5toexml.py
@@ -1,0 +1,57 @@
+'''
+Tests for ph5toexml
+'''
+import unittest
+import os
+import sys
+import shutil
+
+from mock import patch
+from xml.etree import ElementTree as ET
+
+from ph5.utilities import nuke_table
+from ph5.clients import ph5toexml
+from ph5.core.tests.test_base import LogTestCase, TempDirTestCase, kef_to_ph5
+
+
+class TestPH5toexml_ResetShotsForEachShotline(
+        LogTestCase, TempDirTestCase):
+    def tearDown(self):
+        try:
+            self.mng.ph5.close()
+        except AttributeError:
+            pass
+        super(TestPH5toexml_ResetShotsForEachShotline, self).tearDown()
+
+    def test_main(self):
+        metapath = os.path.join(
+            self.home, "ph5/test_data/metadata")
+        ph5_path = os.path.join(self.home, "ph5/test_data/ph5/master.ph5")
+        shutil.copy(ph5_path, '.')
+        # replace event table with event_t_2shotlines.kef that have
+        # shotline 001 with shot 7001 and shotline 002 with shot 7002
+        test_args = ['delete_table', '-n', 'master.ph5', '--all_events']
+        with patch.object(sys, 'argv', test_args):
+            nuke_table.main()
+        kef_to_ph5(self.tmpdir, 'master.ph5',
+                   metapath, ['event_t_2shotlines.kef'])
+
+        # run exml and check total of event tags created
+        # Before fixing so that shots is reset for each shot_line,
+        # there were 4 event tags.
+        # After fixing, there should be 2 event tags.
+        testargs = ['ph5toexml', '-n', 'master.ph5', '-p', '.',
+                    '-o', 'output.xml']
+        count = 0
+        with patch.object(sys, 'argv', testargs):
+            ph5toexml.main()
+            tree = ET.parse('output.xml')
+            root = tree.getroot()
+            for event in root.iter():
+                if event.tag.endswith("event"):
+                    count += 1
+        self.assertEqual(count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ph5/test_data/metadata/event_t_2shotlines.kef
+++ b/ph5/test_data/metadata/event_t_2shotlines.kef
@@ -1,0 +1,48 @@
+#
+#	Sat Mar  9 03:48:54 2019	ph5 version: 4.1.2
+#
+#   Table row 1
+/Experiment_g/Sorts_g/Event_t_001
+	id_s=7001
+	location/X/value_d=-106.912169
+	location/X/units_s=degrees
+	location/Y/value_d=34.123673
+	location/Y/units_s=degrees
+	location/Z/value_d=1403.0
+	location/Z/units_s=m
+	location/coordinate_system_s=
+	location/projection_s=
+	location/ellipsoid_s=
+	location/description_s=
+	time/ascii_s=2019:53:15:41:00.00
+	time/epoch_l=1550850060
+	time/micro_seconds_i=0
+	time/type_s=BOTH
+	size/value_d=1
+	size/units_s=lb
+	depth/value_d=0
+	depth/units_s=m
+	description_s=sample description
+
+#   Table row 2
+/Experiment_g/Sorts_g/Event_t_002
+	id_s=7002
+	location/X/value_d=-106.912169
+	location/X/units_s=degrees
+	location/Y/value_d=34.123673
+	location/Y/units_s=degrees
+	location/Z/value_d=1403.0
+	location/Z/units_s=m
+	location/coordinate_system_s=
+	location/projection_s=
+	location/ellipsoid_s=
+	location/description_s=
+	time/ascii_s=2019:53:15:41:00.00
+	time/epoch_l=1550850060
+	time/micro_seconds_i=0
+	time/type_s=BOTH
+	size/value_d=1
+	size/units_s=lb
+	depth/value_d=0
+	depth/units_s=m
+	description_s=sample description


### PR DESCRIPTION
### What does this PR do?
Reset list of shots to add to shotline at the beginning of loop for shots of a shotline

### Relevant Issues?
Closes #563

### Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests pass.
- [ ] Any new or changed features have are documented.
- [x] Changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
